### PR TITLE
SKRF-142 design: 헤더 레이아웃 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/Header/Header.style.ts
+++ b/src/components/common/Header/Header.style.ts
@@ -1,0 +1,35 @@
+import Theme from '@/styles/Theme';
+import styled from '@emotion/styled';
+
+interface HeaderProps {
+  page: 'main' | 'club';
+}
+
+const HeaderContainerStyled = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 80%;
+  min-width: 60rem;
+  border-bottom: 0.07rem solid ${Theme.color.lineColor};
+`;
+
+const LogoWrapperStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const OptionWrapperStyled = styled.div<HeaderProps>`
+  display: flex;
+  width: 75%;
+  justify-content: ${({ page }) => (page === 'main' ? 'space-between' : 'flex-end')};
+  align-items: center;
+`;
+
+const ChildrenStyled = styled.div<HeaderProps>`
+  display: flex;
+  justify-content: space-between;
+  width: ${({ page }) => (page === 'main' ? '100%' : '40%')};
+`;
+
+export { HeaderContainerStyled, LogoWrapperStyled, OptionWrapperStyled, ChildrenStyled };

--- a/src/components/common/Header/Header.style.ts
+++ b/src/components/common/Header/Header.style.ts
@@ -1,13 +1,17 @@
 import Theme from '@/styles/Theme';
 import styled from '@emotion/styled';
 
-interface HeaderProps {
-  page: 'main' | 'club';
-}
+const HeaderLayoutStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  width: 100%;
+  height: 15vh;
+  min-height: 4rem;
+`;
 
 const HeaderContainerStyled = styled.div`
   display: flex;
-  justify-content: space-between;
   width: 80%;
   min-width: 60rem;
   border-bottom: 0.07rem solid ${Theme.color.lineColor};
@@ -19,17 +23,10 @@ const LogoWrapperStyled = styled.div`
   align-items: center;
 `;
 
-const OptionWrapperStyled = styled.div<HeaderProps>`
+const ChildrenContainerStyled = styled.div`
   display: flex;
-  width: 75%;
-  justify-content: ${({ page }) => (page === 'main' ? 'space-between' : 'flex-end')};
+  flex-grow: 1;
   align-items: center;
 `;
 
-const ChildrenStyled = styled.div<HeaderProps>`
-  display: flex;
-  justify-content: space-between;
-  width: ${({ page }) => (page === 'main' ? '100%' : '40%')};
-`;
-
-export { HeaderContainerStyled, LogoWrapperStyled, OptionWrapperStyled, ChildrenStyled };
+export { HeaderLayoutStyled, HeaderContainerStyled, LogoWrapperStyled, ChildrenContainerStyled };

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -2,27 +2,26 @@ import { ReactNode } from 'react';
 
 import SpaceClubHomeLogo from '../SpaceClubHomeLogo/SpaceClubHomeLogo';
 import {
-  ChildrenStyled,
+  ChildrenContainerStyled,
   HeaderContainerStyled,
+  HeaderLayoutStyled,
   LogoWrapperStyled,
-  OptionWrapperStyled,
 } from './Header.style';
 
 interface HeaderProps {
-  page: 'main' | 'club';
   children?: ReactNode;
 }
 
-const Header = ({ page, children }: HeaderProps) => {
+const Header = ({ children }: HeaderProps) => {
   return (
-    <HeaderContainerStyled>
-      <LogoWrapperStyled>
-        <SpaceClubHomeLogo />
-      </LogoWrapperStyled>
-      <OptionWrapperStyled page={page}>
-        <ChildrenStyled page={page}>{children}</ChildrenStyled>
-      </OptionWrapperStyled>
-    </HeaderContainerStyled>
+    <HeaderLayoutStyled>
+      <HeaderContainerStyled>
+        <LogoWrapperStyled>
+          <SpaceClubHomeLogo />
+        </LogoWrapperStyled>
+        <ChildrenContainerStyled>{children}</ChildrenContainerStyled>
+      </HeaderContainerStyled>
+    </HeaderLayoutStyled>
   );
 };
 

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+
+import SpaceClubHomeLogo from '../SpaceClubHomeLogo/SpaceClubHomeLogo';
+import {
+  ChildrenStyled,
+  HeaderContainerStyled,
+  LogoWrapperStyled,
+  OptionWrapperStyled,
+} from './Header.style';
+
+interface HeaderProps {
+  page: 'main' | 'club';
+  children?: ReactNode;
+}
+
+const Header = ({ page, children }: HeaderProps) => {
+  return (
+    <HeaderContainerStyled>
+      <LogoWrapperStyled>
+        <SpaceClubHomeLogo />
+      </LogoWrapperStyled>
+      <OptionWrapperStyled page={page}>
+        <ChildrenStyled page={page}>{children}</ChildrenStyled>
+      </OptionWrapperStyled>
+    </HeaderContainerStyled>
+  );
+};
+
+export default Header;

--- a/src/components/common/SpaceClubHomeLogo/SpaceClubHomeLogo.style.ts
+++ b/src/components/common/SpaceClubHomeLogo/SpaceClubHomeLogo.style.ts
@@ -5,7 +5,7 @@ const ContainerStyled = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 15rem;
+  width: 10rem;
   height: 4rem;
 `;
 

--- a/src/styles/Theme.ts
+++ b/src/styles/Theme.ts
@@ -10,6 +10,7 @@ const color = {
   gray: '#d9d9d9',
   indigo: '#003949',
   logoTextColor: '#fafafa',
+  lineColor: '#261359',
 } as const;
 
 const componentStyle = {


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 헤더 레이아웃 공통 컴포넌트를 구현했습니다. 
- 사용할 때는 헤더에 포함해줄 요소들을 `<Header></Header>`로 묶어주시면 됩니다. 

## 구현 스크린샷
수정 전
![image](https://github.com/Space-Club/Frontend/assets/98521882/69e8c797-b6d4-4ac3-b1fb-41dc6ad49537)

수정 후
![image](https://github.com/Space-Club/Frontend/assets/98521882/f438d180-8871-4089-930d-3f5a1bbabd10)

- 빨간 테두리: 헤더 레이아웃입니다. 
- 까만 테두리: 헤더 영역입니다. children들이 들어오게 되는 곳!


## ✨pr포인트 & 궁금한 점 
- 많은 피드백 환영합니다. 감사합니다!



