### PR TITLE
SKRF-138 design: MainPage ui 구현, EventCard 컴포넌트 수정, Avatar컴포넌트 수정 ...

### DIFF
--- a/src/components/SideBarMyProfile/SideBarMyProfile.style.ts
+++ b/src/components/SideBarMyProfile/SideBarMyProfile.style.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+const MyProfileStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 4.6rem;
+  height: 4.6rem;
+  border-radius: 1.6rem;
+  background: rgba(239, 239, 244, 0.2);
+  box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.25);
+`;
+
+const ProfileImageStyled = styled.div`
+  width: 3.8rem;
+  height: 3.8rem;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+export { MyProfileStyled, ProfileImageStyled };

--- a/src/components/SideBarMyProfile/SideBarMyProfile.tsx
+++ b/src/components/SideBarMyProfile/SideBarMyProfile.tsx
@@ -1,0 +1,23 @@
+import { BiSolidUserCircle } from 'react-icons/bi';
+
+import { MyProfileStyled, ProfileImageStyled } from './SideBarMyProfile.style';
+
+interface SideBarAvatarProps {
+  userProfileImageSrc?: string;
+}
+
+const SideBarMyProfile = ({ userProfileImageSrc, ...props }: SideBarAvatarProps) => {
+  return (
+    <MyProfileStyled {...props}>
+      {userProfileImageSrc ? (
+        <ProfileImageStyled>
+          <img src={userProfileImageSrc} alt="my profile image" />
+        </ProfileImageStyled>
+      ) : (
+        <BiSolidUserCircle size="4.6rem" style={{ fill: 'rgba(239, 239, 244, 0.50)' }} />
+      )}
+    </MyProfileStyled>
+  );
+};
+
+export default SideBarMyProfile;

--- a/src/components/common/Avatar/Avatar.style.ts
+++ b/src/components/common/Avatar/Avatar.style.ts
@@ -1,4 +1,4 @@
-import { AvatarShapeType } from '@/types/user';
+import { AvatarSizeType } from '@/types/user';
 import { getAvatarSize } from '@/utils/getAvatarSize';
 import styled from '@emotion/styled';
 
@@ -7,29 +7,29 @@ const AvatarContainerStyled = styled.div`
   display: inline-flex;
 `;
 
-const ProfileImageStyled = styled.img<AvatarShapeType>`
+const ProfileImageStyled = styled.img<AvatarSizeType>`
   position: relative;
-  width: ${({ avatarShape }) => getAvatarSize(avatarShape)};
-  height: ${({ avatarShape }) => getAvatarSize(avatarShape)};
-  border-radius: ${({ avatarShape }) => (avatarShape === 'rectangle' ? '1.7rem' : '50%')};
+  width: ${({ avatarSize }) => getAvatarSize(avatarSize)};
+  height: ${({ avatarSize }) => getAvatarSize(avatarSize)};
+  border-radius: 50%;
   object-fit: cover;
 `;
 
-const DefaultImageStyled = styled.div<AvatarShapeType>`
+const DefaultImageStyled = styled.div<AvatarSizeType>`
   position: relative;
-  width: ${({ avatarShape }) => getAvatarSize(avatarShape)};
-  height: ${({ avatarShape }) => getAvatarSize(avatarShape)};
-  border-radius: ${({ avatarShape }) => (avatarShape === 'rectangle' ? '1.7rem' : '50%')};
-  background-color: white;
+  width: ${({ avatarSize }) => getAvatarSize(avatarSize)};
+  height: ${({ avatarSize }) => getAvatarSize(avatarSize)};
+  border-radius: 50%;
+  background-color: #cccccc;
   object-fit: cover;
 `;
 
-const EditButtonStyled = styled.div<AvatarShapeType>`
+const EditButtonStyled = styled.div<AvatarSizeType>`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: ${({ avatarShape }) => (avatarShape === 'large' ? '4rem' : '1.5rem')};
-  height: ${({ avatarShape }) => (avatarShape === 'large' ? '4rem' : '1.5rem')};
+  width: ${({ avatarSize }) => (avatarSize === 'large' ? '4rem' : '1.5rem')};
+  height: ${({ avatarSize }) => (avatarSize === 'large' ? '4rem' : '1.5rem')};
   position: absolute;
   right: 2%;
   bottom: 2%;
@@ -38,10 +38,4 @@ const EditButtonStyled = styled.div<AvatarShapeType>`
   cursor: pointer;
 `;
 
-export {
-  getAvatarSize,
-  AvatarContainerStyled,
-  ProfileImageStyled,
-  DefaultImageStyled,
-  EditButtonStyled,
-};
+export { AvatarContainerStyled, ProfileImageStyled, DefaultImageStyled, EditButtonStyled };

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,8 +1,9 @@
-import { AvatarShapeType } from '@/types/user';
+import { AvatarSizeType } from '@/types/user';
 import { getAvatarSize } from '@/utils/getAvatarSize';
 
 import { AiFillEdit } from 'react-icons/ai';
 import { BiSolidUserCircle } from 'react-icons/bi';
+import { IoPeopleCircleSharp } from 'react-icons/io5';
 
 import {
   AvatarContainerStyled,
@@ -12,27 +13,32 @@ import {
 } from './Avatar.style';
 
 interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
-  avatarShape: AvatarShapeType['avatarShape'];
+  avatarSize: AvatarSizeType['avatarSize'];
   profileImageSrc?: string;
   isEditable?: boolean;
+  isClub?: boolean;
 }
 
-const Avatar = ({ avatarShape, profileImageSrc, isEditable }: AvatarProps) => {
-  const defaultIconSize = getAvatarSize(avatarShape);
-  const editIconSize = isEditable ? (avatarShape === 'large' ? '3rem' : '1rem') : undefined;
+const Avatar = ({ avatarSize, profileImageSrc, isEditable, isClub }: AvatarProps) => {
+  const defaultIconSize = getAvatarSize(avatarSize);
+  const editIconSize = isEditable ? (avatarSize === 'large' ? '3rem' : '1rem') : undefined;
 
   return (
     <div>
       <AvatarContainerStyled>
         {profileImageSrc ? (
-          <ProfileImageStyled avatarShape={avatarShape} src={profileImageSrc} alt="profile image" />
+          <ProfileImageStyled avatarSize={avatarSize} src={profileImageSrc} alt="profile image" />
         ) : (
-          <DefaultImageStyled avatarShape={avatarShape}>
-            <BiSolidUserCircle size={`${defaultIconSize}`} />
+          <DefaultImageStyled avatarSize={avatarSize}>
+            {isClub ? (
+              <IoPeopleCircleSharp size={defaultIconSize} color="#A89BB9" />
+            ) : (
+              <BiSolidUserCircle size={defaultIconSize} color="#A89BB9" />
+            )}
           </DefaultImageStyled>
         )}
         {isEditable && (
-          <EditButtonStyled avatarShape={avatarShape}>
+          <EditButtonStyled avatarSize={avatarSize}>
             <AiFillEdit size={editIconSize} />
           </EditButtonStyled>
         )}

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -7,11 +7,6 @@ const ContainerStyled = styled.div`
   font-family: 'MainThin';
   margin-bottom: 5%;
   cursor: pointer;
-  transition: transform 0.3s ease;
-
-  &:hover {
-    transform: scale(1.02);
-  }
 `;
 
 const PosterAreaStyled = styled.div`
@@ -38,6 +33,11 @@ const TitleStyled = styled.div`
 `;
 
 const EventDateStyled = styled.div`
+  padding-bottom: 2%;
+  font-size: 1rem;
+`;
+
+const EventTimeStyled = styled.div`
   font-size: 1rem;
 `;
 
@@ -71,6 +71,7 @@ export {
   EventInfoWrapper,
   TitleStyled,
   EventDateStyled,
+  EventTimeStyled,
   EventFooterWrapper,
   PlaceStyled,
   ClubInfoWrapperStyle,

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -8,7 +8,6 @@ const ContainerStyled = styled.div`
   margin-bottom: 5%;
   cursor: pointer;
   transition: transform 0.3s ease;
-  border: 1px solid red;
 
   &:hover {
     transform: scale(1.02);

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -25,7 +25,9 @@ const EventInfoWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   flex-direction: column;
-  margin: 3%;
+  width: 100%;
+  height: 100%;
+  margin: 0 3%;
   word-break: break-all;
 `;
 
@@ -55,6 +57,7 @@ const PlaceStyled = styled.div`
 const ClubInfoWrapperStyle = styled.div`
   display: flex;
   align-items: center;
+  gap: 0.3rem;
 `;
 
 const ClubNameStyled = styled.div`

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -2,11 +2,13 @@ import styled from '@emotion/styled';
 
 const ContainerStyled = styled.div`
   display: flex;
-  width: 25rem;
-  height: 17rem;
+  width: 20.3rem;
+  height: 13.3rem;
   font-family: 'MainThin';
+  margin-bottom: 5%;
   cursor: pointer;
   transition: transform 0.3s ease;
+  border: 1px solid red;
 
   &:hover {
     transform: scale(1.02);
@@ -17,8 +19,7 @@ const PosterAreaStyled = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 12rem;
-  height: 17rem;
+  object-fit: cover;
 `;
 
 const EventInfoWrapper = styled.div`
@@ -26,6 +27,7 @@ const EventInfoWrapper = styled.div`
   justify-content: space-between;
   flex-direction: column;
   margin: 3%;
+  word-break: break-all;
 `;
 
 const TitleStyled = styled.div`
@@ -42,7 +44,6 @@ const EventFooterWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: end;
   height: 20%;
   margin-right: 3%;
 `;
@@ -50,6 +51,11 @@ const EventFooterWrapper = styled.div`
 const PlaceStyled = styled.div`
   color: grey;
   font-size: 1rem;
+`;
+
+const ClubInfoWrapperStyle = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 const ClubNameStyled = styled.div`
@@ -65,5 +71,6 @@ export {
   EventDateStyled,
   EventFooterWrapper,
   PlaceStyled,
+  ClubInfoWrapperStyle,
   ClubNameStyled,
 };

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -8,6 +8,7 @@ import {
   EventDateStyled,
   EventFooterWrapper,
   EventInfoWrapper,
+  EventTimeStyled,
   PlaceStyled,
   PosterAreaStyled,
   TitleStyled,
@@ -18,6 +19,7 @@ interface EventProps {
   eventPoster: string;
   eventTitle: string;
   eventDate: string;
+  eventTime: string;
   eventPlace: string;
   clubImageSrc?: string;
   clubName: string;
@@ -28,6 +30,7 @@ const EventCard = ({
   eventPoster,
   eventTitle,
   eventDate,
+  eventTime,
   eventPlace,
   clubImageSrc,
   clubName,
@@ -43,6 +46,7 @@ const EventCard = ({
         <div>
           <TitleStyled>{eventTitle}</TitleStyled>
           <EventDateStyled>{eventDate}</EventDateStyled>
+          <EventTimeStyled>{eventTime}</EventTimeStyled>
         </div>
         <EventFooterWrapper>
           <PlaceStyled>{eventPlace}</PlaceStyled>

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router-dom';
 
+import Avatar from '../Avatar/Avatar';
 import {
+  ClubInfoWrapperStyle,
   ClubNameStyled,
   ContainerStyled,
   EventDateStyled,
@@ -17,6 +19,7 @@ interface EventProps {
   eventTitle: string;
   eventDate: string;
   eventPlace: string;
+  clubImageSrc?: string;
   clubName: string;
 }
 
@@ -26,6 +29,7 @@ const EventCard = ({
   eventTitle,
   eventDate,
   eventPlace,
+  clubImageSrc,
   clubName,
 }: EventProps) => {
   const navigate = useNavigate();
@@ -42,7 +46,10 @@ const EventCard = ({
         </div>
         <EventFooterWrapper>
           <PlaceStyled>{eventPlace}</PlaceStyled>
-          <ClubNameStyled>{clubName}</ClubNameStyled>
+          <ClubInfoWrapperStyle>
+            <Avatar avatarShape="small" profileImageSrc={clubImageSrc} />
+            <ClubNameStyled>{clubName}</ClubNameStyled>
+          </ClubInfoWrapperStyle>
         </EventFooterWrapper>
       </EventInfoWrapper>
     </ContainerStyled>

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -47,7 +47,7 @@ const EventCard = ({
         <EventFooterWrapper>
           <PlaceStyled>{eventPlace}</PlaceStyled>
           <ClubInfoWrapperStyle>
-            <Avatar avatarShape="small" profileImageSrc={clubImageSrc} />
+            <Avatar avatarSize="small" profileImageSrc={clubImageSrc} isClub={true} />
             <ClubNameStyled>{clubName}</ClubNameStyled>
           </ClubInfoWrapperStyle>
         </EventFooterWrapper>

--- a/src/pages/Layout/SideNav.tsx
+++ b/src/pages/Layout/SideNav.tsx
@@ -1,4 +1,5 @@
 import getMyClub from '@/apis/users/getMyClub';
+import SideBarMyProfile from '@/components/SideBarMyProfile/SideBarMyProfile';
 import Avatar from '@/components/common/Avatar/Avatar';
 
 import { FaBell, FaHome, FaPlusCircle } from 'react-icons/fa';
@@ -27,7 +28,7 @@ const SideNav = () => {
       <FaHome className={iconStyle} onClick={() => navigate('/')} />
       <FaBell className={iconStyle} onClick={() => alert('알림페이지 준비 중')} />
       <Link to={`/profile`}>
-        <Avatar avatarSize="normal" />
+        <SideBarMyProfile />
       </Link>
     </Container>
   );

--- a/src/pages/Layout/SideNav.tsx
+++ b/src/pages/Layout/SideNav.tsx
@@ -19,7 +19,7 @@ const SideNav = () => {
       <AvatarGroup>
         {clubs?.map((club) => (
           <Link to={`/club/home/${club.id}`}>
-            <Avatar key={club.id} avatarShape="normal" profileImageSrc={club.src}></Avatar>
+            <Avatar key={club.id} avatarSize="normal" profileImageSrc={club.src}></Avatar>
           </Link>
         ))}
       </AvatarGroup>
@@ -27,7 +27,7 @@ const SideNav = () => {
       <FaHome className={iconStyle} onClick={() => navigate('/')} />
       <FaBell className={iconStyle} onClick={() => alert('알림페이지 준비 중')} />
       <Link to={`/profile`}>
-        <Avatar avatarShape="rectangle" />
+        <Avatar avatarSize="normal" />
       </Link>
     </Container>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,8 +1,33 @@
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
+import Banner from '@/components/common/Banner/Banner';
+import EventCard from '@/components/common/EventCard/EventCard';
 import Header from '@/components/common/Header/Header';
 import Tab from '@/components/common/Tab/Tab';
 import { TAB_CONSTANTS } from '@/constants/tab';
 import { TabContextProvider } from '@/context/TabContext';
+import styled from '@emotion/styled';
+
+const ContentContainerStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid;
+`;
+
+const BannerWrapperStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 5% 0;
+`;
+
+const EventCardWrapperStyled = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 5%;
+  border: 1px solid;
+`;
 
 const MainPage = () => {
   return (
@@ -24,6 +49,45 @@ const MainPage = () => {
           ]}
         />
       </Header>
+      <ContentContainerStyled>
+        <BannerWrapperStyled>
+          <Banner width={35} height={20} />
+        </BannerWrapperStyled>
+        <EventCardWrapperStyled>
+          <EventCard
+            eventId={1}
+            eventPoster="https://picsum.photos/153/213"
+            eventTitle="연어 전시회"
+            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventPlace="하천대강당"
+            clubName="불곰"
+          />
+          <EventCard
+            eventId={2}
+            eventPoster="https://picsum.photos/153/213"
+            eventTitle="연어 전시회"
+            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventPlace="하천대강당"
+            clubName="불곰"
+          />
+          <EventCard
+            eventId={3}
+            eventPoster="https://picsum.photos/153/213"
+            eventTitle="연어 전시회"
+            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventPlace="하천대강당"
+            clubName="불곰"
+          />
+          <EventCard
+            eventId={4}
+            eventPoster="https://picsum.photos/153/213"
+            eventTitle="연어 전시회"
+            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventPlace="하천대강당"
+            clubName="불곰"
+          />
+        </EventCardWrapperStyled>
+      </ContentContainerStyled>
     </TabContextProvider>
   );
 };

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -58,7 +58,7 @@ const MainPage = () => {
             eventId={1}
             eventPoster="https://picsum.photos/153/213"
             eventTitle="연어 전시회"
-            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventDate="2023/10/29, 15시 30분"
             eventPlace="하천대강당"
             clubName="불곰"
           />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -11,7 +11,6 @@ const ContentContainerStyled = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  border: 1px solid;
 `;
 
 const BannerWrapperStyled = styled.div`
@@ -26,7 +25,6 @@ const EventCardWrapperStyled = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   margin-bottom: 5%;
-  border: 1px solid;
 `;
 
 const MainPage = () => {
@@ -58,7 +56,7 @@ const MainPage = () => {
             eventId={1}
             eventPoster="https://picsum.photos/153/213"
             eventTitle="연어 전시회"
-            eventDate="2023/10/29, 15시 30분"
+            eventDate="2023/10/29, 15시 30분 dfad"
             eventPlace="하천대강당"
             clubName="불곰"
           />
@@ -68,6 +66,7 @@ const MainPage = () => {
             eventTitle="연어 전시회"
             eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
             eventPlace="하천대강당"
+            clubImageSrc="https://picsum.photos/200"
             clubName="불곰"
           />
           <EventCard
@@ -76,6 +75,7 @@ const MainPage = () => {
             eventTitle="연어 전시회"
             eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
             eventPlace="하천대강당"
+            clubImageSrc="https://picsum.photos/200"
             clubName="불곰"
           />
           <EventCard

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -57,6 +57,7 @@ const MainPage = () => {
             eventPoster="https://picsum.photos/153/213"
             eventTitle="연어 전시회"
             eventDate="2023/10/29, 15시 30분 dfad"
+            eventTime="15시 30분"
             eventPlace="하천대강당"
             clubName="불곰"
           />
@@ -64,7 +65,8 @@ const MainPage = () => {
             eventId={2}
             eventPoster="https://picsum.photos/153/213"
             eventTitle="연어 전시회"
-            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventDate="2023/10/29"
+            eventTime="15시 30분"
             eventPlace="하천대강당"
             clubImageSrc="https://picsum.photos/200"
             clubName="불곰"
@@ -72,19 +74,21 @@ const MainPage = () => {
           <EventCard
             eventId={3}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어 전시회"
+            eventTitle="연어 전시회가나다라알말"
             eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventTime="15시 30분"
             eventPlace="하천대강당"
             clubImageSrc="https://picsum.photos/200"
-            clubName="불곰"
+            clubName="불곰열글자라면어떨까가나다"
           />
           <EventCard
             eventId={4}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어 전시회"
+            eventTitle="연어불곰합동 전시회"
             eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
+            eventTime="15시 30분"
             eventPlace="하천대강당"
-            clubName="불곰"
+            clubName="호엔하임"
           />
         </EventCardWrapperStyled>
       </ContentContainerStyled>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -5,6 +5,7 @@ import Header from '@/components/common/Header/Header';
 import Tab from '@/components/common/Tab/Tab';
 import { TAB_CONSTANTS } from '@/constants/tab';
 import { TabContextProvider } from '@/context/TabContext';
+import { truncateText } from '@/utils/truncateText';
 import styled from '@emotion/styled';
 
 const ContentContainerStyled = styled.div`
@@ -55,40 +56,40 @@ const MainPage = () => {
           <EventCard
             eventId={1}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어 전시회"
-            eventDate="2023/10/29, 15시 30분 dfad"
+            eventTitle={truncateText('연어 전시회1', 13)}
+            eventDate="2023/10/29"
             eventTime="15시 30분"
-            eventPlace="하천대강당"
-            clubName="불곰"
+            eventPlace={truncateText('코엑스', 10)}
+            clubName={truncateText('불곰', 12)}
           />
           <EventCard
             eventId={2}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어 전시회"
-            eventDate="2023/10/29"
-            eventTime="15시 30분"
-            eventPlace="하천대강당"
+            eventTitle={truncateText('가나다라마바사아자차카타파하', 13)}
+            eventDate="2023/10/30"
+            eventTime="15시"
+            eventPlace={truncateText('어디긴 네 마음이지 라는 본심을 숨기며', 10)}
             clubImageSrc="https://picsum.photos/200"
-            clubName="불곰"
+            clubName={truncateText('어제는 공연을 봤는데 오랜만에', 12)}
           />
           <EventCard
             eventId={3}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어 전시회가나다라알말"
-            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
-            eventTime="15시 30분"
-            eventPlace="하천대강당"
+            eventTitle={truncateText('추억의 8090: 그날의 우리', 13)}
+            eventDate="2023/10/31"
+            eventTime="16시"
+            eventPlace={truncateText('우리집', 10)}
             clubImageSrc="https://picsum.photos/200"
-            clubName="불곰열글자라면어떨까가나다"
+            clubName={truncateText('pinkfloyd', 12)}
           />
           <EventCard
             eventId={4}
             eventPoster="https://picsum.photos/153/213"
-            eventTitle="연어불곰합동 전시회"
-            eventDate="2023/10/29, 15시 30분ㅇㄻㄴㄻㄴㅇㄻㄴㄹㄹ"
-            eventTime="15시 30분"
-            eventPlace="하천대강당"
-            clubName="호엔하임"
+            eventTitle={truncateText('BornToBe', 13)}
+            eventDate="2023/10/32"
+            eventTime="32시 68분"
+            eventPlace={truncateText('화성', 10)}
+            clubName={truncateText('외존믿모', 12)}
           />
         </EventCardWrapperStyled>
       </ContentContainerStyled>

--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+const ContentContainerStyled = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const BannerWrapperStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 5% 0;
+`;
+
+const EventCardWrapperStyled = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 5%;
+`;
+
+export { ContentContainerStyled, BannerWrapperStyled, EventCardWrapperStyled };

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -6,27 +6,12 @@ import Tab from '@/components/common/Tab/Tab';
 import { TAB_CONSTANTS } from '@/constants/tab';
 import { TabContextProvider } from '@/context/TabContext';
 import { truncateText } from '@/utils/truncateText';
-import styled from '@emotion/styled';
 
-const ContentContainerStyled = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const BannerWrapperStyled = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 5% 0;
-`;
-
-const EventCardWrapperStyled = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 5%;
-`;
+import {
+  BannerWrapperStyled,
+  ContentContainerStyled,
+  EventCardWrapperStyled,
+} from './MainPage.style';
 
 const MainPage = () => {
   return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,8 @@
 import App from '@/App';
-
 import FormLayout from '@/pages/FormLayout/FormLayout';
 import Layout from '@/pages/Layout/Layout';
 import LoginPage from '@/pages/LoginPage/LoginPage';
-import MainPage from '@/pages/MainPage';
+import MainPage from '@/pages/MainPage/MainPage';
 import NotFoundPage from '@/pages/NotFoundPage';
 import OauthRedirectPage from '@/pages/OauthRedirectPage';
 import ProfilePage from '@/pages/ProfilePage';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,8 +2,8 @@ interface User {
   token: string;
 }
 
-interface AvatarShapeType {
-  avatarShape: 'rectangle' | 'normal' | 'large' | 'small' | 'medium';
+interface AvatarSizeType {
+  avatarSize: 'normal' | 'large' | 'small' | 'medium';
 }
 
-export { User, AvatarShapeType };
+export { User, AvatarSizeType };

--- a/src/utils/getAvatarSize.ts
+++ b/src/utils/getAvatarSize.ts
@@ -1,17 +1,15 @@
-import { AvatarShapeType } from '@/types/user';
+import { AvatarSizeType } from '@/types/user';
 
-export const getAvatarSize = (avatarShape: AvatarShapeType['avatarShape']) => {
-  switch (avatarShape) {
+export const getAvatarSize = (avatarSize: AvatarSizeType['avatarSize']) => {
+  switch (avatarSize) {
     case 'small':
-      return '1.5rem';
+      return '1.3rem';
     case 'normal':
-      return '4rem';
-    case 'rectangle':
-      return '4.5rem';
+      return '3.7rem';
     case 'medium':
-      return '6.875rem';
+      return '6.6rem';
     case 'large':
-      return '16.3rem';
+      return '16rem';
     default:
       return '4rem';
   }

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,0 +1,6 @@
+export function truncateText(text: string, maxLength: number) {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength) + '...';
+}


### PR DESCRIPTION
## 📝요구사항과 구현내용
- MainPage의 ui를 구현했습니다. 
- EventCard 컴포넌트를 수정했습니다. 디자인 수정사항과 반응형 반영, 애니메이션 삭제(포스터 컴포넌트에 구현되어 있는 것 같길래 삭제했습니다)
- Avatar 컴포넌트의 디자인을 수정했습니다. 
- new! SideBarMyProfile 컴포넌트가 만들어졌습니다. 사각형 아바타는 사이드바에서만 쓰이고, 사이드바의 프로필 사진의 스타일이 다른 아바타와 많이 달라져서 일반 컴포넌트로 분리하였습니다. 
- truncate 함수를 만들고 적용해봤습니다. 

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/98521882/516c01ec-480b-44c3-a12d-d12f44ee2899)

## ✨pr포인트 & 궁금한 점 
- EventCard가 줄바꿈 될 때 요소가 가운데로 위치하는 것은...의도한 바는 아닙니다.
- EventCard에서 날짜와 시간은 길이가 정해져 있지만, 다른 정보들은 사용자가 직접 작성하는 부분이라 텍스트 길이가 길어지면 ui가 깨지길래 truncate라는 것을 사용해 보았습니다. 그런데 이런 식으로 사용하는 게 맞는지 잘 모르겠습니다...! 


