### PR TITLE
SKRF-268 fix : 내가 신청한 행사 조회 api 변수명 동기화

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -14,7 +14,7 @@ const END_POINTS = {
   GET_EVENT_DETAIL: '/events',
   ALL_EVENTS: '/events',
   POST_EVENT_APPLY: '/events/apply',
-  CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/cancel`,
+  CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/applications`,
 
   CREATE_CLUB: '/clubs',
   INVITE_LINK: (clubId: string) => `/clubs/${clubId}/invite`,

--- a/src/constants/event.ts
+++ b/src/constants/event.ts
@@ -13,8 +13,8 @@ const APPLIED_EVENTS_TAGS: EventTags = {
     backgroundColor: 'tSemiPurple',
     textColor: 'white',
   },
-  CANCELLED: {
-    title: '취소확정',
+  CANCELED: {
+    title: '취소완료',
     borderColor: 'tBlue',
     backgroundColor: 'tSemiBlue',
     textColor: 'white',

--- a/src/hooks/query/event/useCancelEventMutation.ts
+++ b/src/hooks/query/event/useCancelEventMutation.ts
@@ -14,7 +14,7 @@ const useCancelEventMutation = () => {
   const { mutate: requestCancel } = useMutation({
     mutationFn: cancelEvent,
     onSuccess: ({ applicationStatus }) => {
-      if (applicationStatus === 'CANCELLED') {
+      if (applicationStatus === 'CANCELED') {
         createToast({ message: SUCCESS_MESSAGE.EVENT.CANCELLED, toastType: 'success' });
       } else if (applicationStatus === 'CANCEL_REQUESTED') {
         createToast({

--- a/src/hooks/query/event/useCancelEventMutation.ts
+++ b/src/hooks/query/event/useCancelEventMutation.ts
@@ -13,10 +13,10 @@ const useCancelEventMutation = () => {
 
   const { mutate: requestCancel } = useMutation({
     mutationFn: cancelEvent,
-    onSuccess: ({ eventStatus }) => {
-      if (eventStatus === 'CANCELLED') {
+    onSuccess: ({ applicationStatus }) => {
+      if (applicationStatus === 'CANCELLED') {
         createToast({ message: SUCCESS_MESSAGE.EVENT.CANCELLED, toastType: 'success' });
-      } else if (eventStatus === 'CANCEL_REQUESTED') {
+      } else if (applicationStatus === 'CANCEL_REQUESTED') {
         createToast({
           message: SUCCESS_MESSAGE.EVENT.CANCEL_REQUESTED,
           toastType: 'success',

--- a/src/mocks/data/eventData.ts
+++ b/src/mocks/data/eventData.ts
@@ -9,7 +9,7 @@ const appliedEvent: GetAppliedEventResponse = {
       clubName: 'test',
       startDate: '2021-10-10',
       location: 'test',
-      status: 'CANCELLED',
+      status: 'CANCELED',
       posterImageUrl:
         'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
     },
@@ -19,7 +19,7 @@ const appliedEvent: GetAppliedEventResponse = {
       clubName: 'test',
       startDate: '2021-10-10',
       location: 'test',
-      status: 'CANCELLED',
+      status: 'CANCELED',
       posterImageUrl: 'https://www.europosters.ie/image/framed/750/115398_modenacerna.jpg',
     },
   ],

--- a/src/pages/Layout/SideNav.tsx
+++ b/src/pages/Layout/SideNav.tsx
@@ -41,7 +41,7 @@ const SideNav = () => {
       <IoMdHome className={iconStyle} onClick={() => navigate('/')} />
       <IoMdNotifications className={iconStyle} onClick={() => alert('알림페이지 준비 중')} />
       {isLoginUser ? (
-        <Link to={`/profile`}>
+        <Link to={PATH.PROFILE_APPLIED}>
           <SideBarMyProfile profileImageUrl={userImage?.profileImageUrl} />
         </Link>
       ) : (

--- a/src/pages/ProfilePage/AppliedEvents.tsx
+++ b/src/pages/ProfilePage/AppliedEvents.tsx
@@ -13,6 +13,8 @@ const AppliedEvents = () => {
 
   if (!events || !pageData) return null;
 
+  console.log(events);
+
   const { totalPages, size } = pageData;
 
   const onChangePage = (page: number) => {

--- a/src/pages/ProfilePage/AppliedEvents.tsx
+++ b/src/pages/ProfilePage/AppliedEvents.tsx
@@ -13,8 +13,6 @@ const AppliedEvents = () => {
 
   if (!events || !pageData) return null;
 
-  console.log(events);
-
   const { totalPages, size } = pageData;
 
   const onChangePage = (page: number) => {

--- a/src/types/api/cancelEvent.ts
+++ b/src/types/api/cancelEvent.ts
@@ -5,7 +5,7 @@ interface CancelEventRequest {
 }
 
 interface CancelEventResponse {
-  eventStatus: EventStatus;
+  applicationStatus: EventStatus;
 }
 
 export { CancelEventRequest, CancelEventResponse };

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,6 +1,6 @@
 import Theme from '@/styles/Theme';
 
-type EventStatus = 'CONFIRMED' | 'PENDING' | 'CANCEL_REQUESTED' | 'CANCELLED';
+type EventStatus = 'CONFIRMED' | 'PENDING' | 'CANCEL_REQUESTED' | 'CANCELED';
 
 type EventTagKey = 'publicEvent' | 'clubOnlyEvent' | EventStatus;
 


### PR DESCRIPTION
## 📝요구사항과 구현내용
- cancelled => canceled로 오타 잡았습니다 cancelled는 영국식 영어더군요...ㅋㅋ
- eventStatus => apillicationStatus : api명세에서 바뀐 변수명 적용했습니다
- 취소 신청 테스트까지 완료했습니다!
- 취소확정 => 취소완료 : 태그 메시지 변경했습니다! 취소완료가 더 어울릴 것 같아서?

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/42764685/fa1c1f16-2080-461d-9c00-483756e585bb)

## ✨pr포인트 & 궁금한 점 



