### PR TITLE
SKRF-287 fix: 클럽 바뀔 때마다 클럽일정 api 호출

### DIFF
--- a/src/components/ScheduleManage/ScheduleManage.tsx
+++ b/src/components/ScheduleManage/ScheduleManage.tsx
@@ -9,7 +9,6 @@ import { ScheduleManageContainer } from './ScheduleManage.style';
 
 const ScheduleManage = () => {
   const { clubId } = useParams() as { clubId: string };
-  console.log(clubId);
   const { data } = useClubSchedulesQuery({ clubId });
   if (!data) {
     return null;

--- a/src/components/ScheduleManage/ScheduleManage.tsx
+++ b/src/components/ScheduleManage/ScheduleManage.tsx
@@ -9,6 +9,7 @@ import { ScheduleManageContainer } from './ScheduleManage.style';
 
 const ScheduleManage = () => {
   const { clubId } = useParams() as { clubId: string };
+  console.log(clubId);
   const { data } = useClubSchedulesQuery({ clubId });
   if (!data) {
     return null;

--- a/src/hooks/query/event/useClubSchedulesQuery.ts
+++ b/src/hooks/query/event/useClubSchedulesQuery.ts
@@ -4,13 +4,11 @@ import { GetClubSchedulesRequest } from '@/types/api/getClubSchedules';
 import { useQuery } from '@tanstack/react-query';
 
 export const QUERY_KEY = { CLUB_SCHEDULES: 'CLUB_SCHEDULES' };
-const SCHEDULES_STALE_TIME = 1000 * 60;
 
 const useClubSchedulesQuery = ({ clubId }: GetClubSchedulesRequest) => {
   const { data } = useQuery({
-    queryKey: [QUERY_KEY.CLUB_SCHEDULES],
+    queryKey: [QUERY_KEY.CLUB_SCHEDULES, clubId],
     queryFn: () => getClubSchedules({ clubId }),
-    staleTime: SCHEDULES_STALE_TIME,
   });
 
   return { data };


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 클럽 일정을 불러올 때 staleTime으로 인해 클럽에 따른 일정이 불러와지지 않는 문제를 해결했습니다. 
- 같은 queryKey에 캐싱된 데이터가 유효하면 staleTime 동안에는 새로운 데이터 요청을 보내지 않는다고 하네요. 근데 clubId는 달라지는데, 그럼 무효한 데이터가 되지 않나..? 이 부분에 대해서는 더 찾아보고 개발일지에 남기도록 하겠습니다. 

## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



