### PR TITLE
SKRF-319 feat: 검색 기능, 검색페이지 구현

### DIFF
--- a/src/apis/club/getClubEvents.ts
+++ b/src/apis/club/getClubEvents.ts
@@ -5,7 +5,7 @@ import { axiosClientWithAuth } from '../axiosClient';
 
 const getClubEvents = async ({ clubId, pageNumber }: GetClubEventsRequest) => {
   const { data } = await axiosClientWithAuth.get<GetClubEventsResponse>(
-    `${END_POINTS.CLUB_EVENTS({ clubId })}?page=${pageNumber}&size=10&sort=id%2C,asc`,
+    END_POINTS.CLUB_EVENTS({ clubId, pageNumber }),
   );
   return data;
 };

--- a/src/apis/event/getAllEvents.ts
+++ b/src/apis/event/getAllEvents.ts
@@ -5,7 +5,7 @@ import { axiosClient } from '../axiosClient';
 
 const getAllEvents = async ({ pageNumber, category, sort }: AllEventsRequest) => {
   const { data } = await axiosClient.get<AllEventsResponse>(
-    `${END_POINTS.ALL_EVENTS}?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
+    END_POINTS.ALL_EVENTS({ category, pageNumber, sort }),
   );
   return data;
 };

--- a/src/apis/event/getAllEvents.ts
+++ b/src/apis/event/getAllEvents.ts
@@ -1,10 +1,10 @@
 import { END_POINTS } from '@/constants/api';
-import { GetAllEventsRequest, GetAllEventsResponse } from '@/types/event';
+import { AllEventsRequest, AllEventsResponse } from '@/types/api/allEvents';
 
 import { axiosClient } from '../axiosClient';
 
-const getAllEvents = async ({ pageNumber, category, sort }: GetAllEventsRequest) => {
-  const { data } = await axiosClient.get<GetAllEventsResponse>(
+const getAllEvents = async ({ pageNumber, category, sort }: AllEventsRequest) => {
+  const { data } = await axiosClient.get<AllEventsResponse>(
     `${END_POINTS.ALL_EVENTS}?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
   );
   return data;

--- a/src/apis/event/getSearchResult.ts
+++ b/src/apis/event/getSearchResult.ts
@@ -1,0 +1,12 @@
+import { SearchResultRequest, SearchResultResponse } from '@/types/api/searchResult';
+
+import { axiosClient } from '../axiosClient';
+
+const getSearchResult = async ({ keyword, page }: SearchResultRequest) => {
+  const { data } = await axiosClient.get<SearchResultResponse>(
+    `/events/searches?keyword=${keyword}&page=${page}&size=18&sort=id,desc`,
+  );
+  return data;
+};
+
+export default getSearchResult;

--- a/src/apis/event/getSearchResult.ts
+++ b/src/apis/event/getSearchResult.ts
@@ -1,10 +1,11 @@
+import { END_POINTS } from '@/constants/api';
 import { SearchResultRequest, SearchResultResponse } from '@/types/api/searchResult';
 
 import { axiosClient } from '../axiosClient';
 
 const getSearchResult = async ({ keyword, page }: SearchResultRequest) => {
   const { data } = await axiosClient.get<SearchResultResponse>(
-    `/events/searches?keyword=${keyword}&page=${page}&size=18&sort=id,desc`,
+    END_POINTS.SEARCHES({ keyword, page }),
   );
   return data;
 };

--- a/src/apis/event/getSubmittedForms.ts
+++ b/src/apis/event/getSubmittedForms.ts
@@ -5,7 +5,7 @@ import { axiosClientWithAuth } from '../axiosClient';
 
 const getSubmittedForms = async ({ eventId, pageNumber }: GetSubmittedFormsRequest) => {
   const { data } = await axiosClientWithAuth.get<GetSubmittedFormsResponse>(
-    `${END_POINTS.GET_SUBMITTED_FORMS({ eventId })}?page=${pageNumber}&size=3&sort=id,desc`,
+    END_POINTS.GET_SUBMITTED_FORMS({ eventId, pageNumber }),
   );
 
   return data;

--- a/src/components/SearchInputForm/SearchInputForm.style.ts
+++ b/src/components/SearchInputForm/SearchInputForm.style.ts
@@ -69,6 +69,13 @@ const NoResultStyled = styled.div`
   font-size: ${Theme.fontSize.smallContent};
 `;
 
+const MoreResultStyled = styled(NoResultStyled)`
+  cursor: pointer;
+  :hover {
+    background-color: ${Theme.color.calendarHover};
+  }
+`;
+
 export {
   SearchInputContainerStyled,
   SearchBarStyled,
@@ -77,4 +84,5 @@ export {
   SearchTitleStyled,
   SearchResultsWrapper,
   NoResultStyled,
+  MoreResultStyled,
 };

--- a/src/components/SearchInputForm/SearchInputForm.style.ts
+++ b/src/components/SearchInputForm/SearchInputForm.style.ts
@@ -6,6 +6,7 @@ const SearchInputContainerStyled = styled.div`
   justify-content: center;
   align-items: center;
   flex-grow: 1;
+  position: relative;
   height: 100%;
 `;
 
@@ -36,4 +37,34 @@ const IconContainerStyled = styled.div`
   cursor: pointer;
 `;
 
-export { SearchInputContainerStyled, SearchBarStyled, SearchInputStyled, IconContainerStyled };
+const SearchResultsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 40rem;
+  width: 90%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, 6%);
+  padding: 0.5rem 0;
+  border: 1px solid ${Theme.color.tWhiteGrey};
+  border-radius: 0.6rem;
+  background-color: white;
+  filter: drop-shadow(0px 2px 2px rgba(0, 0, 0, 0.25));
+  z-index: 5;
+`;
+
+const SearchTitleStyled = styled.div`
+  padding: 1rem 1rem 0.5rem 1rem;
+  color: black;
+  font-size: ${Theme.fontSize.smallContent};
+`;
+
+export {
+  SearchInputContainerStyled,
+  SearchBarStyled,
+  SearchInputStyled,
+  IconContainerStyled,
+  SearchTitleStyled,
+  SearchResultsWrapper,
+};

--- a/src/components/SearchInputForm/SearchInputForm.style.ts
+++ b/src/components/SearchInputForm/SearchInputForm.style.ts
@@ -33,6 +33,7 @@ const IconContainerStyled = styled.div`
   align-items: center;
   margin-right: 0.5rem;
   color: ${Theme.color.lineColor};
+  cursor: pointer;
 `;
 
 export { SearchInputContainerStyled, SearchBarStyled, SearchInputStyled, IconContainerStyled };

--- a/src/components/SearchInputForm/SearchInputForm.style.ts
+++ b/src/components/SearchInputForm/SearchInputForm.style.ts
@@ -1,4 +1,5 @@
 import Theme from '@/styles/Theme';
+import { sideBarScrollAreaStyled } from '@/styles/common';
 import styled from '@emotion/styled';
 
 const SearchInputContainerStyled = styled.div`
@@ -37,11 +38,13 @@ const IconContainerStyled = styled.div`
   cursor: pointer;
 `;
 
-const SearchResultsWrapper = styled.div`
+const SearchResultsWrapper = styled(sideBarScrollAreaStyled)`
   display: flex;
   flex-direction: column;
   max-width: 40rem;
   width: 90%;
+  height: 17rem;
+  overflow: auto;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -60,6 +63,12 @@ const SearchTitleStyled = styled.div`
   font-size: ${Theme.fontSize.smallContent};
 `;
 
+const NoResultStyled = styled.div`
+  padding-left: 1rem;
+  color: ${Theme.color.semiBlack};
+  font-size: ${Theme.fontSize.smallContent};
+`;
+
 export {
   SearchInputContainerStyled,
   SearchBarStyled,
@@ -67,4 +76,5 @@ export {
   IconContainerStyled,
   SearchTitleStyled,
   SearchResultsWrapper,
+  NoResultStyled,
 };

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -20,8 +20,8 @@ import {
 const SearchInputForm = () => {
   const [keyword, setKeyword] = useState('');
   const [isFocused, setIsFocused] = useState(false);
-  const debouncedKeyword = useDebounceValue(keyword, 500);
-  const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 1 });
+  const debouncedKeyword = useDebounceValue(keyword, 1000);
+  const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 0 });
   const navigate = useNavigate();
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -1,5 +1,5 @@
 import { PATH } from '@/constants/path';
-// import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
+import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
 import useDebounceValue from '@/hooks/useDebounce';
 
 import { useState } from 'react';
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import SearchResult from '../SearchResult/SearchResult';
 import {
   IconContainerStyled,
+  NoResultStyled,
   SearchBarStyled,
   SearchInputContainerStyled,
   SearchInputStyled,
@@ -18,8 +19,9 @@ import {
 
 const SearchInputForm = () => {
   const [keyword, setKeyword] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
   const debouncedKeyword = useDebounceValue(keyword, 1000);
-  // const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 1 });
+  const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 1 });
   const navigate = useNavigate();
 
   return (
@@ -30,30 +32,33 @@ const SearchInputForm = () => {
             placeholder="검색하기"
             value={keyword}
             onChange={(event) => setKeyword(event.target.value)}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
           />
           <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
             <CiSearch size="1.5rem" />
           </IconContainerStyled>
         </SearchBarStyled>
-        <SearchResultsWrapper>
-          <SearchTitleStyled>검색 결과</SearchTitleStyled>
-          <SearchResult
-            eventId="1"
-            eventTitle="연사모"
-            posterImageUrl="https://picsum.photos/200/300"
-            location="우리집"
-            eventStartDate="10101010"
-            clubName="연사모"
-          />
-          <SearchResult
-            eventId="1"
-            eventTitle="연사모asfjlsjflsf"
-            posterImageUrl="https://picsum.photos/200/300"
-            location="우리집asldfjals"
-            formEndDate="10101010"
-            clubName="연사모"
-          />
-        </SearchResultsWrapper>
+        {isFocused && (
+          <SearchResultsWrapper>
+            <SearchTitleStyled>{`"${debouncedKeyword}" 검색 결과`}</SearchTitleStyled>
+            {data?.length ? (
+              data.map((event) => (
+                <SearchResult
+                  key={event.id}
+                  eventId={event.id}
+                  eventTitle={event.eventInfo.title}
+                  posterImageUrl={event.eventInfo.posterImageUrl}
+                  location={event.eventInfo.location}
+                  formEndDate={event.formInfo.endDate}
+                  clubName={event.clubInfo.name}
+                />
+              ))
+            ) : (
+              <NoResultStyled>검색결과가 없습니다.</NoResultStyled>
+            )}
+          </SearchResultsWrapper>
+        )}
       </SearchInputContainerStyled>
     </>
   );

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -65,7 +65,12 @@ const SearchInputForm = () => {
             <NoResultStyled>검색결과가 없습니다.</NoResultStyled>
           )}
           {pageData && pageData.totalPages > 0 && (
-            <MoreResultStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
+            <MoreResultStyled
+              onClick={() => {
+                navigate(`${PATH.SEARCH}/${debouncedKeyword}`);
+                console.log('onClickMore');
+              }}
+            >
               검색결과 더 보러 가기
             </MoreResultStyled>
           )}

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -1,5 +1,7 @@
 import { PATH } from '@/constants/path';
+import useDebounceValue from '@/hooks/useDebounce';
 
+import { useState } from 'react';
 import { CiSearch } from 'react-icons/ci';
 import { useNavigate } from 'react-router-dom';
 
@@ -11,12 +13,20 @@ import {
 } from './SearchInputForm.style';
 
 const SearchInputForm = () => {
+  const [keyword, setKeyword] = useState('');
+  const debouncedKeyword = useDebounceValue(keyword, 1000);
   const navigate = useNavigate();
+
+  console.log(debouncedKeyword);
 
   return (
     <SearchInputContainerStyled>
       <SearchBarStyled>
-        <SearchInputStyled placeholder="검색하기" />
+        <SearchInputStyled
+          placeholder="검색하기"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+        />
         <IconContainerStyled onClick={() => navigate(PATH.SEARCH)}>
           <CiSearch size="1.5rem" />
         </IconContainerStyled>

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import SearchResult from '../SearchResult/SearchResult';
 import {
   IconContainerStyled,
+  MoreResultStyled,
   NoResultStyled,
   SearchBarStyled,
   SearchInputContainerStyled,
@@ -21,7 +22,7 @@ const SearchInputForm = () => {
   const [keyword, setKeyword] = useState('');
   const [isFocused, setIsFocused] = useState(false);
   const debouncedKeyword = useDebounceValue(keyword, 1000);
-  const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 0 });
+  const { data, pageData } = useSearchResultQuery({ keyword: debouncedKeyword, page: 0 });
   const navigate = useNavigate();
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -31,43 +32,46 @@ const SearchInputForm = () => {
   };
 
   return (
-    <>
-      <SearchInputContainerStyled>
-        <SearchBarStyled>
-          <SearchInputStyled
-            placeholder="검색하기"
-            value={keyword}
-            onChange={(event) => setKeyword(event.target.value)}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
-            onKeyDown={(event) => handleKeyDown(event)}
-          />
-          <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
-            <CiSearch size="1.5rem" />
-          </IconContainerStyled>
-        </SearchBarStyled>
-        {isFocused && (
-          <SearchResultsWrapper>
-            <SearchTitleStyled>{`"${debouncedKeyword}" 검색 결과`}</SearchTitleStyled>
-            {data?.length ? (
-              data.map((event) => (
-                <SearchResult
-                  key={event.id}
-                  eventId={event.id}
-                  eventTitle={event.eventInfo.title}
-                  posterImageUrl={event.eventInfo.posterImageUrl}
-                  location={event.eventInfo.location}
-                  formEndDate={event.formInfo.endDate}
-                  clubName={event.clubInfo.name}
-                />
-              ))
-            ) : (
-              <NoResultStyled>검색결과가 없습니다.</NoResultStyled>
-            )}
-          </SearchResultsWrapper>
-        )}
-      </SearchInputContainerStyled>
-    </>
+    <SearchInputContainerStyled>
+      <SearchBarStyled>
+        <SearchInputStyled
+          placeholder="검색하기"
+          value={keyword}
+          onChange={(event) => setKeyword(event.target.value)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          onKeyDown={(event) => handleKeyDown(event)}
+        />
+        <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
+          <CiSearch size="1.5rem" />
+        </IconContainerStyled>
+      </SearchBarStyled>
+      {isFocused && (
+        <SearchResultsWrapper>
+          <SearchTitleStyled>{`"${debouncedKeyword}" 검색 결과`}</SearchTitleStyled>
+          {data?.length ? (
+            data.map((event) => (
+              <SearchResult
+                key={event.id}
+                eventId={event.id}
+                eventTitle={event.eventInfo.title}
+                posterImageUrl={event.eventInfo.posterImageUrl}
+                location={event.eventInfo.location}
+                formEndDate={event.formInfo.endDate}
+                clubName={event.clubInfo.name}
+              />
+            ))
+          ) : (
+            <NoResultStyled>검색결과가 없습니다.</NoResultStyled>
+          )}
+          {pageData && pageData.totalPages > 0 && (
+            <MoreResultStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
+              검색결과 더 보러 가기
+            </MoreResultStyled>
+          )}
+        </SearchResultsWrapper>
+      )}
+    </SearchInputContainerStyled>
   );
 };
 

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -1,4 +1,7 @@
+import { PATH } from '@/constants/path';
+
 import { CiSearch } from 'react-icons/ci';
+import { useNavigate } from 'react-router-dom';
 
 import {
   IconContainerStyled,
@@ -8,11 +11,13 @@ import {
 } from './SearchInputForm.style';
 
 const SearchInputForm = () => {
+  const navigate = useNavigate();
+
   return (
     <SearchInputContainerStyled>
       <SearchBarStyled>
-        <SearchInputStyled />
-        <IconContainerStyled>
+        <SearchInputStyled placeholder="검색하기" />
+        <IconContainerStyled onClick={() => navigate(PATH.SEARCH)}>
           <CiSearch size="1.5rem" />
         </IconContainerStyled>
       </SearchBarStyled>

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -20,9 +20,15 @@ import {
 const SearchInputForm = () => {
   const [keyword, setKeyword] = useState('');
   const [isFocused, setIsFocused] = useState(false);
-  const debouncedKeyword = useDebounceValue(keyword, 1000);
+  const debouncedKeyword = useDebounceValue(keyword, 500);
   const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 1 });
   const navigate = useNavigate();
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      navigate(`${PATH.SEARCH}/${debouncedKeyword}`);
+    }
+  };
 
   return (
     <>
@@ -34,6 +40,7 @@ const SearchInputForm = () => {
             onChange={(event) => setKeyword(event.target.value)}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
+            onKeyDown={(event) => handleKeyDown(event)}
           />
           <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
             <CiSearch size="1.5rem" />

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -71,7 +71,6 @@ const SearchInputForm = () => {
             <MoreResultStyled
               onClick={() => {
                 navigate(`${PATH.SEARCH}/${debouncedKeyword}`);
-                console.log('onClickMore');
               }}
             >
               검색결과 더 보러 가기

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -1,37 +1,61 @@
 import { PATH } from '@/constants/path';
+// import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
 import useDebounceValue from '@/hooks/useDebounce';
 
 import { useState } from 'react';
 import { CiSearch } from 'react-icons/ci';
 import { useNavigate } from 'react-router-dom';
 
+import SearchResult from '../SearchResult/SearchResult';
 import {
   IconContainerStyled,
   SearchBarStyled,
   SearchInputContainerStyled,
   SearchInputStyled,
+  SearchResultsWrapper,
+  SearchTitleStyled,
 } from './SearchInputForm.style';
 
 const SearchInputForm = () => {
   const [keyword, setKeyword] = useState('');
   const debouncedKeyword = useDebounceValue(keyword, 1000);
+  // const { data } = useSearchResultQuery({ keyword: debouncedKeyword, page: 1 });
   const navigate = useNavigate();
 
-  console.log(debouncedKeyword);
-
   return (
-    <SearchInputContainerStyled>
-      <SearchBarStyled>
-        <SearchInputStyled
-          placeholder="검색하기"
-          value={keyword}
-          onChange={(event) => setKeyword(event.target.value)}
-        />
-        <IconContainerStyled onClick={() => navigate(PATH.SEARCH)}>
-          <CiSearch size="1.5rem" />
-        </IconContainerStyled>
-      </SearchBarStyled>
-    </SearchInputContainerStyled>
+    <>
+      <SearchInputContainerStyled>
+        <SearchBarStyled>
+          <SearchInputStyled
+            placeholder="검색하기"
+            value={keyword}
+            onChange={(event) => setKeyword(event.target.value)}
+          />
+          <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>
+            <CiSearch size="1.5rem" />
+          </IconContainerStyled>
+        </SearchBarStyled>
+        <SearchResultsWrapper>
+          <SearchTitleStyled>검색 결과</SearchTitleStyled>
+          <SearchResult
+            eventId="1"
+            eventTitle="연사모"
+            posterImageUrl="https://picsum.photos/200/300"
+            location="우리집"
+            eventStartDate="10101010"
+            clubName="연사모"
+          />
+          <SearchResult
+            eventId="1"
+            eventTitle="연사모asfjlsjflsf"
+            posterImageUrl="https://picsum.photos/200/300"
+            location="우리집asldfjals"
+            formEndDate="10101010"
+            clubName="연사모"
+          />
+        </SearchResultsWrapper>
+      </SearchInputContainerStyled>
+    </>
   );
 };
 

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -50,15 +50,15 @@ const SearchInputForm = () => {
         <SearchResultsWrapper>
           <SearchTitleStyled>{`"${debouncedKeyword}" 검색 결과`}</SearchTitleStyled>
           {data?.length ? (
-            data.map((event) => (
+            data.map(({ id, eventInfo, formInfo, clubInfo }) => (
               <SearchResult
-                key={event.id}
-                eventId={event.id}
-                eventTitle={event.eventInfo.title}
-                posterImageUrl={event.eventInfo.posterImageUrl}
-                location={event.eventInfo.location}
-                formEndDate={event.formInfo.endDate}
-                clubName={event.clubInfo.name}
+                key={id}
+                eventId={id}
+                eventTitle={eventInfo.title}
+                posterImageUrl={eventInfo.posterImageUrl}
+                location={eventInfo.location}
+                formEndDate={formInfo.endDate}
+                clubName={clubInfo.name}
               />
             ))
           ) : (

--- a/src/components/SearchInputForm/SearchInputForm.tsx
+++ b/src/components/SearchInputForm/SearchInputForm.tsx
@@ -31,6 +31,10 @@ const SearchInputForm = () => {
     }
   };
 
+  const handleInputClick = () => {
+    setIsFocused(!isFocused);
+  };
+
   return (
     <SearchInputContainerStyled>
       <SearchBarStyled>
@@ -38,8 +42,7 @@ const SearchInputForm = () => {
           placeholder="검색하기"
           value={keyword}
           onChange={(event) => setKeyword(event.target.value)}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
+          onClick={() => handleInputClick()}
           onKeyDown={(event) => handleKeyDown(event)}
         />
         <IconContainerStyled onClick={() => navigate(`${PATH.SEARCH}/${debouncedKeyword}`)}>

--- a/src/components/SearchResult/SearchResult.style.ts
+++ b/src/components/SearchResult/SearchResult.style.ts
@@ -1,0 +1,38 @@
+import Theme from '@/styles/Theme';
+import styled from '@emotion/styled';
+
+const SearchResultContainer = styled.div`
+  display: flex;
+  width: 100%;
+  gap: 0.5rem;
+  padding: 1rem;
+
+  :hover {
+    background-color: ${Theme.color.tWhiteGrey};
+    cursor: pointer;
+  }
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${Theme.color.idkGrey};
+`;
+
+const InfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const TitleStyled = styled.span`
+  color: black;
+  font-size: ${Theme.fontSize.smallContent};
+`;
+
+const InfoStyled = styled.span`
+  color: ${Theme.color.semiBlack};
+  font-size: ${Theme.fontSize.tagText};
+`;
+
+export { SearchResultContainer, IconWrapper, InfoWrapper, TitleStyled, InfoStyled };

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -41,7 +41,7 @@ const SearchResult = ({
       <Poster width={3} posterSrc={posterImageUrl} />
       <InfoWrapper>
         <TitleStyled>{eventTitle}</TitleStyled>
-        <InfoStyled>{eventStartDate ?? `~${formEndDate}`}</InfoStyled>
+        <InfoStyled>{eventStartDate ?? (formEndDate ? `~${formEndDate}` : '')}</InfoStyled>
         <InfoStyled>{location}</InfoStyled>
         <InfoStyled>{clubName}</InfoStyled>
       </InfoWrapper>

--- a/src/components/SearchResult/SearchResult.tsx
+++ b/src/components/SearchResult/SearchResult.tsx
@@ -1,0 +1,52 @@
+import { PATH } from '@/constants/path';
+
+import { RiFileSearchFill } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
+
+import Poster from '../common/Poster/Poster';
+import {
+  IconWrapper,
+  InfoStyled,
+  InfoWrapper,
+  SearchResultContainer,
+  TitleStyled,
+} from './SearchResult.style';
+
+interface SearchResultProps {
+  eventId: string;
+  eventTitle: string;
+  posterImageUrl: string;
+  location?: string;
+  eventStartDate?: string;
+  formEndDate?: string;
+  clubName: string;
+}
+
+const SearchResult = ({
+  eventId,
+  eventTitle,
+  posterImageUrl,
+  location,
+  eventStartDate,
+  formEndDate,
+  clubName,
+}: SearchResultProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <SearchResultContainer onClick={() => navigate(PATH.EVENT.DETAIL(eventId))}>
+      <IconWrapper>
+        <RiFileSearchFill size={20} />
+      </IconWrapper>
+      <Poster width={3} posterSrc={posterImageUrl} />
+      <InfoWrapper>
+        <TitleStyled>{eventTitle}</TitleStyled>
+        <InfoStyled>{eventStartDate ?? `~${formEndDate}`}</InfoStyled>
+        <InfoStyled>{location}</InfoStyled>
+        <InfoStyled>{clubName}</InfoStyled>
+      </InfoWrapper>
+    </SearchResultContainer>
+  );
+};
+
+export default SearchResult;

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -54,7 +54,9 @@ const EventCard = ({
       <EventInfoWrapper>
         <div>
           <TitleStyled>{eventTitle}</TitleStyled>
-          <EventDateStyled>{eventDate ?? `~${formCloseDate}`}</EventDateStyled>
+          <EventDateStyled>
+            {eventDate ?? (formCloseDate ? `~${formCloseDate}` : '')}
+          </EventDateStyled>
         </div>
         <EventFooterWrapper>
           <PlaceStyled>{eventPlace}</PlaceStyled>

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -1,4 +1,5 @@
 import { APPLIED_EVENTS_TAGS } from '@/constants/event';
+import { PATH } from '@/constants/path';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -43,7 +44,7 @@ const EventCard = ({
   const navigate = useNavigate();
 
   return (
-    <ContainerStyled onClick={() => navigate(`/event/detail/${eventId}`)}>
+    <ContainerStyled onClick={() => navigate(PATH.EVENT.DETAIL(eventId))}>
       <Poster posterSrc={posterSrc} width={9.5}>
         {openStatus && (
           <EventStatusTag

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -36,7 +36,7 @@ const END_POINTS = {
   INVITE_CLUB_CODE: (inviteCode: string) => `/clubs/invite/${inviteCode}`,
   CLUB_MEMBERS: (clubId: string) => `/clubs/${clubId}/members`,
   CLUB_EVENTS: ({ clubId, pageNumber }: { clubId: string; pageNumber: number }) =>
-    `/clubs/${clubId}/events?page=${pageNumber}&size=18&sort=id,asc`,
+    `/clubs/${clubId}/events?page=${pageNumber}&size=18&sort=id,desc`,
   PATCH_MEMBER_ROLE: ({ clubId, memberId }: { clubId: string; memberId: string }) =>
     `/clubs/${clubId}/members/${memberId}`,
   EDIT_CLUB_SETTING: ({ clubId }: { clubId: string }) => `/clubs/${clubId}`,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -15,7 +15,15 @@ const END_POINTS = {
     `users/events?page=${page}&size=${size}&sort=${sort}`,
   GET_EVENT_DETAIL: '/events',
   GET_EVENT_FORM: (eventId: string) => `/events/${eventId}/forms`,
-  ALL_EVENTS: '/events',
+  ALL_EVENTS: ({
+    category,
+    pageNumber,
+    sort,
+  }: {
+    category: string;
+    pageNumber: number;
+    sort: string;
+  }) => `events?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
   EVENT_APPLY: '/events/applications',
   CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/applications`,
   GET_SUBMITTED_FORMS: ({ eventId }: { eventId: string | number }) =>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -26,8 +26,8 @@ const END_POINTS = {
   }) => `events?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
   EVENT_APPLY: '/events/applications',
   CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/applications`,
-  GET_SUBMITTED_FORMS: ({ eventId }: { eventId: string | number }) =>
-    `events/${eventId}/forms/applications`,
+  GET_SUBMITTED_FORMS: ({ eventId, pageNumber }: { eventId: string; pageNumber: number }) =>
+    `events/${eventId}/forms/applications?page=${pageNumber}&size=20&sort=id,desc`,
 
   CREATE_CLUB: '/clubs',
   INVITE_LINK: (clubId: string) => `/clubs/${clubId}/invite`,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -33,7 +33,8 @@ const END_POINTS = {
   INVITE_LINK: (clubId: string) => `/clubs/${clubId}/invite`,
   INVITE_CLUB_CODE: (inviteCode: string) => `/clubs/invite/${inviteCode}`,
   CLUB_MEMBERS: (clubId: string) => `/clubs/${clubId}/members`,
-  CLUB_EVENTS: ({ clubId }: { clubId: number | string }) => `/clubs/${clubId}/events`,
+  CLUB_EVENTS: ({ clubId, pageNumber }: { clubId: string; pageNumber: number }) =>
+    `/clubs/${clubId}/events?page=${pageNumber}&size=18&sort=id,asc`,
   PATCH_MEMBER_ROLE: ({ clubId, memberId }: { clubId: string; memberId: string }) =>
     `/clubs/${clubId}/members/${memberId}`,
   EDIT_CLUB_SETTING: ({ clubId }: { clubId: string }) => `/clubs/${clubId}`,

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -28,6 +28,8 @@ const END_POINTS = {
   CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/applications`,
   GET_SUBMITTED_FORMS: ({ eventId, pageNumber }: { eventId: string; pageNumber: number }) =>
     `events/${eventId}/forms/applications?page=${pageNumber}&size=20&sort=id,desc`,
+  SEARCHES: ({ keyword, page }: { keyword: string; page: number }) =>
+    `/events/searches?keyword=${keyword}&page=${page}&size=18&sort=id,desc`,
 
   CREATE_CLUB: '/clubs',
   INVITE_LINK: (clubId: string) => `/clubs/${clubId}/invite`,

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -10,6 +10,7 @@ const PATH = {
   MAIN_RECRUITMENT: '/recruitment',
   PROFILE_APPLIED: '/profile/applied',
   PROFILE_BOOKMARK: '/profile/bookmark',
+  SEARCH: '/search',
 
   CLUB: {
     HOME: (clubId: string | number) => `/club/${clubId}/home`,

--- a/src/hooks/query/club/useClubEventsQuery.ts
+++ b/src/hooks/query/club/useClubEventsQuery.ts
@@ -8,7 +8,7 @@ export const QUERY_KEY = { CLUB_EVENTS: 'CLUB_EVENTS' };
 const CLUB_EVENTS_STALE_TIME = 1000 * 60;
 
 const useClubEventsQuery = ({ clubId, pageNumber }: GetClubEventsRequest) => {
-  const { data: clubEvents, isLoading } = useQuery({
+  const { data: clubEvents } = useQuery({
     queryKey: [QUERY_KEY.CLUB_EVENTS],
     queryFn: () => getClubEvents({ clubId, pageNumber }),
     staleTime: CLUB_EVENTS_STALE_TIME,
@@ -16,7 +16,7 @@ const useClubEventsQuery = ({ clubId, pageNumber }: GetClubEventsRequest) => {
 
   const { data, pageData } = clubEvents ?? {};
 
-  return { clubEvents: data, pageData, isLoading };
+  return { clubEvents: data, pageData };
 };
 
 export default useClubEventsQuery;

--- a/src/hooks/query/event/useAllEventsQuery.ts
+++ b/src/hooks/query/event/useAllEventsQuery.ts
@@ -1,14 +1,11 @@
 import getAllEvents from '@/apis/event/getAllEvents';
-import { GetAllEventsRequest } from '@/types/event';
+import { AllEventsRequest } from '@/types/api/allEvents';
 
 import { useQuery } from '@tanstack/react-query';
 
 export const QUERY_KEY = { SHOW: 'SHOW', PROMOTION: 'PROMOTION', RECRUITMENT: 'RECRUITMENT' };
 
-const useAllEventsQuery = (
-  { pageNumber, category, sort }: GetAllEventsRequest,
-  pathname: string,
-) => {
+const useAllEventsQuery = ({ pageNumber, category, sort }: AllEventsRequest, pathname: string) => {
   const { data: allEvents } = useQuery({
     queryKey: [
       pathname === '/'

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -1,0 +1,19 @@
+import getSearchResult from '@/apis/event/getSearchResult';
+import { SearchResultRequest } from '@/types/api/searchResult';
+
+import { useQuery } from '@tanstack/react-query';
+
+export const QUERY_KEY = { SEARCH_RESULT: 'SEARCH_RESULT' };
+
+const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
+  const { data: searchResultData } = useQuery({
+    queryKey: [QUERY_KEY.SEARCH_RESULT],
+    queryFn: () => getSearchResult({ keyword, page }),
+  });
+
+  const { data, pageData } = searchResultData ?? {};
+
+  return { data, pageData };
+};
+
+export default useSearchResultQuery;

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -12,8 +12,6 @@ const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
     enabled: !!keyword,
   });
 
-  console.log('data:', searchResultData);
-
   const { data, pageData } = searchResultData ?? {};
 
   return { data, pageData, isLoading };

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -6,7 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 export const QUERY_KEY = { SEARCH_RESULT: 'SEARCH_RESULT' };
 
 const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
-  const { data: searchResultData, isLoading } = useQuery({
+  const { data: searchResultData } = useQuery({
     queryKey: [QUERY_KEY.SEARCH_RESULT, keyword],
     queryFn: () => getSearchResult({ keyword, page }),
     enabled: !!keyword,
@@ -14,7 +14,7 @@ const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
 
   const { data, pageData } = searchResultData ?? {};
 
-  return { data, pageData, isLoading };
+  return { data, pageData };
 };
 
 export default useSearchResultQuery;

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -6,14 +6,15 @@ import { useQuery } from '@tanstack/react-query';
 export const QUERY_KEY = { SEARCH_RESULT: 'SEARCH_RESULT' };
 
 const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
-  const { data: searchResultData } = useQuery({
-    queryKey: [QUERY_KEY.SEARCH_RESULT],
+  const { data: searchResultData, isLoading } = useQuery({
+    queryKey: [QUERY_KEY.SEARCH_RESULT, keyword],
     queryFn: () => getSearchResult({ keyword, page }),
+    enabled: !!keyword,
   });
 
   const { data, pageData } = searchResultData ?? {};
 
-  return { data, pageData };
+  return { data, pageData, isLoading };
 };
 
 export default useSearchResultQuery;

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -12,6 +12,8 @@ const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
     enabled: !!keyword,
   });
 
+  console.log('data:', searchResultData);
+
   const { data, pageData } = searchResultData ?? {};
 
   return { data, pageData, isLoading };

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+export default function useDebounceValue<T>(value: T, delay: number = 1000) {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/mocks/data/eventData.ts
+++ b/src/mocks/data/eventData.ts
@@ -1,6 +1,6 @@
+import { AllEventsResponse } from '@/types/api/allEvents';
 import { GetAppliedEventResponse } from '@/types/api/getAppliedEvent';
 import { ShowDetailResponse } from '@/types/api/getEventDetail';
-import { GetAllEventsResponse } from '@/types/event';
 
 const appliedEvent: GetAppliedEventResponse = {
   data: [
@@ -34,45 +34,70 @@ const appliedEvent: GetAppliedEventResponse = {
   },
 };
 
-const allEvents: GetAllEventsResponse = {
+const allEvents: AllEventsResponse = {
   data: [
     {
       id: '1',
-      title: 'test1',
-      posterImageUrl:
-        'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
-      startDate: '2021-10-10',
-      startTime: 'test',
-      formCloseDate: 'test',
-      formCloseTime: 'test',
-      location: 'test',
-      clubName: 'test',
-      clubLogoImageUrl: 'test',
+      eventInfo: {
+        title: 'test1',
+        posterImageUrl:
+          'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
+        startDate: '2021-10-10',
+        startTime: 'test',
+        location: '',
+      },
+      formInfo: {
+        startDate: '',
+        startTime: '',
+        endDate: 'test',
+        endTime: 'test',
+      },
+      clubInfo: {
+        name: 'test',
+        logoImageUrl: 'test',
+      },
     },
     {
       id: '2',
-      title: 'test2',
-      posterImageUrl: 'https://www.europosters.ie/image/framed/750/115398_modenacerna.jpg',
-      startDate: '2021-10-10',
-      startTime: 'test',
-      formCloseDate: 'test',
-      formCloseTime: 'test',
-      location: 'test',
-      clubName: 'test',
-      clubLogoImageUrl: 'test',
+      eventInfo: {
+        title: 'test1',
+        posterImageUrl:
+          'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
+        startDate: '2021-10-10',
+        startTime: 'test',
+        location: '',
+      },
+      formInfo: {
+        startDate: '',
+        startTime: '',
+        endDate: 'test',
+        endTime: 'test',
+      },
+      clubInfo: {
+        name: 'test',
+        logoImageUrl: 'test',
+      },
     },
     {
-      id: '1',
-      title: 'test1',
-      posterImageUrl:
-        'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
-      startDate: '2021-10-10',
-      startTime: 'test',
-      formCloseDate: 'test',
-      formCloseTime: 'test',
-      location: 'test',
-      clubName: 'test',
-      clubLogoImageUrl: 'test',
+      id: '3',
+      eventInfo: {
+        title: 'test1',
+        posterImageUrl:
+          'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
+        startDate: '2021-10-10',
+        startTime: 'test',
+        location: '',
+      },
+      formInfo: {
+        startDate: '',
+        startTime: '',
+        endDate: 'test',
+        endTime: 'test',
+      },
+      clubInfo: {
+        name: 'test',
+        logoImageUrl: 'test',
+      },
     },
   ],
   pageData: {

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -58,12 +58,13 @@ const MainPage = () => {
             return (
               <EventCard
                 eventId={event.id}
-                posterSrc={event.posterImageUrl}
-                eventTitle={event.title}
-                eventDate={event.startDate}
-                formCloseDate={event.formCloseDate}
-                eventPlace={event.location}
-                clubName={event.clubName}
+                posterSrc={event.eventInfo.posterImageUrl}
+                eventTitle={event.eventInfo.title}
+                eventDate={event.eventInfo.startDate}
+                formCloseDate={event.formInfo.endDate}
+                eventPlace={event.eventInfo.location}
+                clubName={event.clubInfo.name}
+                clubImageSrc={event.clubInfo.logoImageUrl}
               />
             );
           })}

--- a/src/pages/SearchResultPage/SearchResultPage.style.ts
+++ b/src/pages/SearchResultPage/SearchResultPage.style.ts
@@ -1,0 +1,27 @@
+import Theme from '@/styles/Theme';
+import styled from '@emotion/styled';
+
+const SearchesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SearchMessageStyled = styled.div`
+  padding: 2rem 2rem;
+  color: black;
+  font-size: ${Theme.fontSize.smallTitle};
+`;
+
+const SearchesWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 5%;
+`;
+
+const PaginationWrapper = styled.div`
+  padding: 2rem 0 5rem 0;
+`;
+
+export { SearchesContainer, SearchMessageStyled, SearchesWrapper, PaginationWrapper };

--- a/src/pages/SearchResultPage/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage/SearchResultPage.tsx
@@ -1,15 +1,61 @@
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
+import EventCard from '@/components/common/EventCard/EventCard';
 import Header from '@/components/common/Header/Header';
+import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
+import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
+
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  PaginationWrapper,
+  SearchMessageStyled,
+  SearchesContainer,
+  SearchesWrapper,
+} from './SearchResultPage.style';
 
 const SearchResultPage = () => {
+  const { keyword } = useParams();
+  const [currentPage, setCurrentPage] = useState(0);
+  const { data, pageData } = useSearchResultQuery({ keyword: keyword ?? '', page: currentPage });
+  if (!pageData) {
+    return null;
+  }
+  const { totalPages, size } = pageData;
+
   return (
     <>
       <Header>
         <SearchInputForm />
         <Tab tabItems={MAIN_TABS} />
       </Header>
+      <SearchMessageStyled>{`"${keyword}" 검색 결과`}</SearchMessageStyled>
+      <SearchesContainer>
+        <SearchesWrapper>
+          {data?.map((event) => (
+            <EventCard
+              key={event.id}
+              eventId={event.id}
+              eventTitle={event.eventInfo.title}
+              eventDate={event.eventInfo.startDate}
+              formCloseDate={event.formInfo.endDate}
+              posterSrc={event.eventInfo.posterImageUrl}
+              eventPlace={event.eventInfo.location}
+              clubName={event.clubInfo.name}
+              clubImageSrc={event.clubInfo.logoImageUrl}
+            />
+          ))}
+        </SearchesWrapper>
+        <PaginationWrapper>
+          <Pagination
+            totalPages={totalPages}
+            size={size}
+            onChangePage={(page) => setCurrentPage(page)}
+          />
+        </PaginationWrapper>
+      </SearchesContainer>
     </>
   );
 };

--- a/src/pages/SearchResultPage/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage/SearchResultPage.tsx
@@ -1,0 +1,17 @@
+import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
+import Header from '@/components/common/Header/Header';
+import Tab from '@/components/common/Tab/Tab';
+import { MAIN_TABS } from '@/constants/tab';
+
+const SearchResultPage = () => {
+  return (
+    <>
+      <Header>
+        <SearchInputForm />
+        <Tab tabItems={MAIN_TABS} />
+      </Header>
+    </>
+  );
+};
+
+export default SearchResultPage;

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -1,21 +1,33 @@
 import ActiveButton from '@/components/ActiveButton/ActiveButton';
 import EventCard from '@/components/common/EventCard/EventCard';
 import Header from '@/components/common/Header/Header';
+import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
 import { TAB_CONSTANTS } from '@/constants/tab';
 import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
 
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ButtonWrapper, EventsContainer, HeaderElementWrapper } from './ClubEventPage.style';
 
 const ClubEventPage = () => {
   const navigate = useNavigate();
+  const [currentPage, setCurrentPage] = useState(0);
   const { clubId } = useParams();
   if (!clubId) throw new Error('클럽 ID를 찾을 수 없습니다');
-  const { clubEvents } = useClubEventsQuery({ clubId, pageNumber: 0 });
+  const { clubEvents, pageData } = useClubEventsQuery({ clubId, pageNumber: currentPage });
+  if (!pageData) {
+    return null;
+  }
+
+  const { totalPages, size } = pageData;
+
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+  };
 
   return (
     <>
@@ -45,6 +57,7 @@ const ClubEventPage = () => {
           />
         ))}
       </EventsContainer>
+      <Pagination totalPages={totalPages} size={size} onChangePage={handleChangePage} />
       <ButtonWrapper>
         <ActiveButton
           buttonText={CREATE_EVENT.BUTTON_TEXT}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -62,7 +62,7 @@ const router = createBrowserRouter([
             ],
           },
           {
-            path: 'search',
+            path: 'search/:keyword',
             element: <SearchResultPage />,
           },
           {

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -7,6 +7,7 @@ import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
 import OauthRedirectPage from '@/pages/OauthRedirectPage';
 import ProfilePage from '@/pages/ProfilePage/ProfilePage';
 import RegisterPage from '@/pages/RegisterPage/RegisterPage';
+import SearchResultPage from '@/pages/SearchResultPage/SearchResultPage';
 import ClubEventPage from '@/pages/club/ClubEventPage/ClubEventPage';
 import ClubHomePage from '@/pages/club/ClubHomePage/ClubHomePage';
 import CreateClubPage from '@/pages/club/CreateClubPage/CreateClubPage';
@@ -59,6 +60,10 @@ const router = createBrowserRouter([
                 element: <MainPage />,
               },
             ],
+          },
+          {
+            path: 'search',
+            element: <SearchResultPage />,
           },
           {
             path: 'profile/:category',

--- a/src/types/api/allEvents.ts
+++ b/src/types/api/allEvents.ts
@@ -3,12 +3,13 @@ import { PageData } from '../common';
 import { EventInfo } from '../event';
 import { FormInfo } from '../form';
 
-interface SearchResultRequest {
-  keyword: string;
-  page: number;
+interface AllEventsRequest {
+  pageNumber: number;
+  category: string;
+  sort: string;
 }
 
-interface SearchResultResponse {
+interface AllEventsResponse {
   data: {
     id: string;
     eventInfo: EventInfo;
@@ -18,4 +19,4 @@ interface SearchResultResponse {
   pageData: PageData;
 }
 
-export { SearchResultRequest, SearchResultResponse };
+export { AllEventsRequest, AllEventsResponse };

--- a/src/types/api/searchResult.ts
+++ b/src/types/api/searchResult.ts
@@ -1,0 +1,32 @@
+import { PageData } from '../common';
+
+interface SearchResultRequest {
+  keyword: string;
+  page: number;
+}
+
+interface SearchResultResponse {
+  data: {
+    id: string;
+    eventInfo: {
+      title: string;
+      posterImageUrl: string;
+      location: string;
+      startDate: string;
+      startTime: string;
+    };
+    formInfo: {
+      startDate: string;
+      startTime: string;
+      endDate: string;
+      endTime: string;
+    };
+    clubInfo: {
+      name: string;
+      logoImageUrl: string;
+    };
+  }[];
+  pageData: PageData;
+}
+
+export { SearchResultRequest, SearchResultResponse };

--- a/src/types/club.ts
+++ b/src/types/club.ts
@@ -19,7 +19,7 @@ interface CreateClubFormValue {
 }
 
 interface GetClubEventsRequest {
-  clubId: number | string;
+  clubId: string;
   pageNumber: number;
 }
 

--- a/src/types/club.ts
+++ b/src/types/club.ts
@@ -10,6 +10,8 @@ interface Club {
   reverse?: boolean;
 }
 
+interface ClubInfo extends Pick<Club, 'name' | 'logoImageUrl'> {}
+
 interface CreateClubFormValue {
   image: File | null;
   name?: string;
@@ -51,4 +53,5 @@ export {
   CreateClubFormValue,
   Club,
   Notice,
+  ClubInfo,
 };

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,6 +1,5 @@
 import Theme from '@/styles/Theme';
 
-import { PageData } from './common';
 import { FormType } from './form';
 
 type EventStatus = 'CONFIRMED' | 'PENDING' | 'CANCEL_REQUESTED' | 'CANCELED';
@@ -35,6 +34,14 @@ interface Event {
   clubLogoImageUrl: string;
 }
 
+interface EventInfo {
+  title: string;
+  posterImageUrl: string;
+  location: string;
+  startDate: string;
+  startTime: string;
+}
+
 interface BookmarkedEvent
   extends Pick<Event, 'id' | 'title' | 'location' | 'clubName' | 'posterImageUrl' | 'startDate'> {
   bookmark: boolean;
@@ -51,28 +58,6 @@ interface Schedule {
 
 interface SchedulesProps {
   schedules: Schedule[];
-}
-
-interface GetAllEventsRequest {
-  pageNumber: number;
-  category: string;
-  sort: string;
-}
-
-interface GetAllEventsResponse {
-  data: {
-    id: string;
-    title: string;
-    posterImageUrl: string;
-    startDate: string;
-    startTime: string;
-    formCloseDate: string;
-    formCloseTime: string;
-    location: string;
-    clubName: string;
-    clubLogoImageUrl: string;
-  }[];
-  pageData: PageData;
 }
 
 interface getEventFormResponse {
@@ -104,8 +89,6 @@ type Value = ValuePiece | [ValuePiece, ValuePiece];
 
 export {
   getEventFormResponse,
-  GetAllEventsRequest,
-  GetAllEventsResponse,
   Event,
   EventTags,
   EventTagKey,
@@ -121,4 +104,5 @@ export {
   ValuePiece,
   Value,
   BookmarkedEvent,
+  EventInfo,
 };

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -13,4 +13,11 @@ interface FormOption {
   visible: boolean;
 }
 
-export { FormType, FormOption, FormOptionButtonText };
+interface FormInfo {
+  startDate: string;
+  startTime: string;
+  endDate: string;
+  endTime: string;
+}
+
+export { FormType, FormOption, FormOptionButtonText, FormInfo };


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 검색 api 연결 및 테스트 완료했습니다. 
- 검색창에 검색어를 입력하면 자동완성 결과가 검색창 아래 나타납니다. (검색결과가 18개가 넘을 경우 검색결과 페이지로 이동하는 버튼 보임)
- 검색어 입력 후 돋보기 버튼을 클릭하거나 엔터를 입력하면 검색결과 페이지로 이동합니다. 

## 구현 스크린샷
아 원래 gif로 만들어서 올리려고 했는데 더미데이터 싹 사라져서 보여드릴 수가 없네요;; 
![ezgif com-video-to-gif (5)](https://github.com/Space-Club/Frontend/assets/98521882/ddf237bf-4f2e-4555-a4a6-90c5fc3fdb06)

## ✨pr포인트 & 궁금한 점 
- 검색창 아래로 내려오는 wrapper의 높이가 고정인 이유는... 그렇게 하지 않으면 검색창 위치가 이상해지기 때문입니다. 네이버처럼 검색창 아래에 딱 붙어서 내려오게 하고 싶은데, 어떻게 하는지 모르겠습니다! 
- 최근 검색어는 당장에 필요한 건 아닐 것 같아서 추후에... 하도록 하겠습니다. 


