### PR TITLE
SKRF-343 feat : 클럽 역할 별 헤더 아이템 변경

### DIFF
--- a/src/components/ClubHeader/ClubHeader.tsx
+++ b/src/components/ClubHeader/ClubHeader.tsx
@@ -1,0 +1,28 @@
+import { CLUB_MANAGER_TABS, CLUB_MEMBER_TABS } from '@/constants/tab';
+import useMemberAuth from '@/hooks/query/club/useMemberAuth';
+import { TabWrapper } from '@/styles/common';
+
+import Header from '../common/Header/Header';
+import Tab from '../common/Tab/Tab';
+
+interface ClubHeaderProps {
+  clubId: string;
+}
+
+const ClubHeader = ({ clubId }: ClubHeaderProps) => {
+  const { data } = useMemberAuth({ clubId });
+
+  if (!data) return null;
+
+  return (
+    <Header>
+      <TabWrapper>
+        <Tab
+          tabItems={data.role === 'MANAGER' ? CLUB_MANAGER_TABS(clubId) : CLUB_MEMBER_TABS(clubId)}
+        />
+      </TabWrapper>
+    </Header>
+  );
+};
+
+export default ClubHeader;

--- a/src/constants/tab.ts
+++ b/src/constants/tab.ts
@@ -24,10 +24,15 @@ const PROFILE_TABS = [
   { title: `${TAB_CONSTANTS.BOOKMARKED_EVENT}`, link: `${PATH.PROFILE_BOOKMARK}` },
 ];
 
-const CLUB_TABS = (clubId: string | number) => [
+const CLUB_MEMBER_TABS = (clubId: string | number) => [
+  { title: `${TAB_CONSTANTS.CLUB_HOME}`, link: `${PATH.CLUB.HOME(clubId)}` },
+  { title: `${TAB_CONSTANTS.CLUB_EVENTS}`, link: `${PATH.CLUB.EVENT(clubId)}` },
+];
+
+const CLUB_MANAGER_TABS = (clubId: string | number) => [
   { title: `${TAB_CONSTANTS.CLUB_HOME}`, link: `${PATH.CLUB.HOME(clubId)}` },
   { title: `${TAB_CONSTANTS.CLUB_EVENTS}`, link: `${PATH.CLUB.EVENT(clubId)}` },
   { title: `${TAB_CONSTANTS.CLUB_MANAGE}`, link: `${PATH.CLUB.MANAGE(clubId)}` },
 ];
 
-export { TAB_CONSTANTS, MAIN_TABS, PROFILE_TABS, CLUB_TABS };
+export { TAB_CONSTANTS, MAIN_TABS, PROFILE_TABS, CLUB_MEMBER_TABS, CLUB_MANAGER_TABS };

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -1,17 +1,14 @@
 import ActiveButton from '@/components/ActiveButton/ActiveButton';
+import ClubHeader from '@/components/ClubHeader/ClubHeader';
 import EventCard from '@/components/common/EventCard/EventCard';
-import Header from '@/components/common/Header/Header';
 import Pagination from '@/components/common/Pagination/Pagination';
-import Tab from '@/components/common/Tab/Tab';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
-import { TAB_CONSTANTS } from '@/constants/tab';
 import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
 
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { TabWrapper } from '../ClubHomePage/ClubHomePage.style';
 import { ButtonWrapper, EventsContainer } from './ClubEventPage.style';
 
 const ClubEventPage = () => {
@@ -32,17 +29,7 @@ const ClubEventPage = () => {
 
   return (
     <>
-      <Header>
-        <TabWrapper>
-          <Tab
-            tabItems={[
-              { title: `${TAB_CONSTANTS.CLUB_HOME}`, link: `${PATH.CLUB.HOME(clubId)}` },
-              { title: `${TAB_CONSTANTS.CLUB_EVENTS}`, link: `${PATH.CLUB.EVENT(clubId)}` },
-              { title: `${TAB_CONSTANTS.CLUB_MANAGE}`, link: `${PATH.CLUB.MANAGE(clubId)}` },
-            ]}
-          />
-        </TabWrapper>
-      </Header>
+      <ClubHeader clubId={clubId}></ClubHeader>
       <EventsContainer>
         {clubEvents?.map((clubEvent) => (
           <EventCard

--- a/src/pages/club/ClubHomePage/ClubHomePage.style.ts
+++ b/src/pages/club/ClubHomePage/ClubHomePage.style.ts
@@ -2,12 +2,6 @@ import Theme from '@/styles/Theme';
 import { memberManagerScrollAreaStyled, whiteGreyBox } from '@/styles/common';
 import styled from '@emotion/styled';
 
-const TabWrapper = styled.div`
-  display: flex;
-  justify-content: end;
-  width: 100%;
-`;
-
 const ClubHomePageContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -74,7 +68,6 @@ const ClubHomeBottomWrapper = styled.section`
 `;
 
 export {
-  TabWrapper,
   ClubHomePageContainer,
   ClubHomeTopWrapper,
   ClubNoticeWrapper,

--- a/src/pages/club/ClubHomePage/ClubHomePage.tsx
+++ b/src/pages/club/ClubHomePage/ClubHomePage.tsx
@@ -1,11 +1,9 @@
+import ClubHeader from '@/components/ClubHeader/ClubHeader';
 import ClubMember from '@/components/ClubMember/ClubMember';
 import ClubNotices from '@/components/ClubNotices/ClubNotices';
 import CreateNoticeButton from '@/components/CreateNoticeButton/CreateNoticeButton';
 import ScheduleManage from '@/components/ScheduleManage/ScheduleManage';
 import ClubBanner from '@/components/common/ClubBanner/ClubBanner';
-import Header from '@/components/common/Header/Header';
-import Tab from '@/components/common/Tab/Tab';
-import { CLUB_TABS } from '@/constants/tab';
 
 import { useParams } from 'react-router-dom';
 
@@ -19,21 +17,15 @@ import {
   ClubNoticeTextStyled,
   ClubNoticeTextedWrapper,
   ClubNoticeWrapper,
-  TabWrapper,
 } from './ClubHomePage.style';
 
 const ClubHomePage = () => {
   const { clubId } = useParams();
   if (!clubId) throw new Error('클럽 ID를 찾을 수 없습니다');
-  //TODO: pathname에 따라 클럽홈/행사/관리 컴포넌트 보여주기
 
   return (
     <>
-      <Header>
-        <TabWrapper>
-          <Tab tabItems={CLUB_TABS(clubId)} />
-        </TabWrapper>
-      </Header>
+      <ClubHeader clubId={clubId} />
       <ClubHomePageContainer>
         <ClubHomeTopWrapper>
           <ClubBanner clubId={clubId} bannerSize="small" />

--- a/src/pages/club/ClubManagePage/ClubManagePage.tsx
+++ b/src/pages/club/ClubManagePage/ClubManagePage.tsx
@@ -1,18 +1,15 @@
+import ClubHeader from '@/components/ClubHeader/ClubHeader';
 import ClubSetting from '@/components/ClubSetting/ClubSetting';
 import InviteLink from '@/components/InviteLink/InviteLink';
 import MemberManager from '@/components/MemberManager/MemberManager';
 import ConfirmModal from '@/components/Modals/ConfirmModal';
-import Header from '@/components/common/Header/Header';
-import Tab from '@/components/common/Tab/Tab';
 import { MODAL_TEXT } from '@/constants/modalMessage';
-import { CLUB_TABS } from '@/constants/tab';
 import useDeleteClubMutation from '@/hooks/query/club/useDeleteClubMutation';
 import useGetClubQuery from '@/hooks/query/club/useGetClubQuery';
 import useModal from '@/hooks/useModal';
 
 import { useParams } from 'react-router-dom';
 
-import { TabWrapper } from '../ClubHomePage/ClubHomePage.style';
 import {
   ClubManagePageContainer,
   ClubManagePageLeftWrapper,
@@ -46,11 +43,7 @@ const ClubManagePage = () => {
           onConfirm={() => deleteClubMutate()}
         />
       )}
-      <Header>
-        <TabWrapper>
-          <Tab tabItems={CLUB_TABS(clubId)} />
-        </TabWrapper>
-      </Header>
+      <ClubHeader clubId={clubId} />
       <ClubManagePageContainer>
         <ClubManagePageLeftWrapper>
           <MemberManager />

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -78,6 +78,12 @@ const SmallTitleStyled = styled.h3`
   font-weight: 700;
 `;
 
+const TabWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  width: 100%;
+`;
+
 const sideBarScrollAreaStyled = styled.div`
   &::-webkit-scrollbar {
     width: 0.3rem;
@@ -136,5 +142,6 @@ export {
   textAreaScrollBar,
   InvisibleInput,
   MediumTitleStyled,
+  TabWrapper,
   SmallTitleStyled,
 };


### PR DESCRIPTION
## 📝요구사항과 구현내용
- [ClubHeader 컴포넌트 추가](https://github.com/Space-Club/Frontend/commit/b8bc14390499b1d4e286acc3b8143be85f0fcca1)
- [tabWrapper 스타일 공통으로 분리](https://github.com/Space-Club/Frontend/commit/996c28ecea388fa9b307a83b2040cfc632b2767f)
- [멤버, 관리자 탭 아이템 상수 분리](https://github.com/Space-Club/Frontend/commit/211908a242c2ab639015aaf69958e0e954f371e8)
- [ClubHeader 각 페이지에 적용](https://github.com/Space-Club/Frontend/commit/03e3a731789ddc5158de7fab21d7613fb438ef97)

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/42764685/e0375b5b-7c4a-49ff-8735-a7aee8c0fd96)
![image](https://github.com/Space-Club/Frontend/assets/42764685/67e4c7ec-cc48-4a54-b15f-b0f17bb5e52f)

## ✨pr포인트 & 궁금한 점 



