### PR TITLE
SKRF-344 fix : 행사 신청 취소 API 스펙 변경

### DIFF
--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -28,7 +28,7 @@ const END_POINTS = {
     sort: string;
   }) => `events?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
   EVENT_APPLY: '/events/applications',
-  CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/applications`,
+  CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/participate`,
   GET_SUBMITTED_FORMS: ({ eventId, pageNumber }: { eventId: string; pageNumber: number }) =>
     `events/${eventId}/forms/applications?page=${pageNumber}&size=20&sort=id,desc`,
   SEARCHES: ({ keyword, page }: { keyword: string; page: number }) =>

--- a/src/hooks/query/event/useCancelEventMutation.ts
+++ b/src/hooks/query/event/useCancelEventMutation.ts
@@ -13,10 +13,10 @@ const useCancelEventMutation = () => {
 
   const { mutate: requestCancel } = useMutation({
     mutationFn: cancelEvent,
-    onSuccess: ({ applicationStatus }) => {
-      if (applicationStatus === 'CANCELED') {
+    onSuccess: ({ participationStatus }) => {
+      if (participationStatus === 'CANCELED') {
         createToast({ message: SUCCESS_MESSAGE.EVENT.CANCELED, toastType: 'success' });
-      } else if (applicationStatus === 'CANCEL_REQUESTED') {
+      } else if (participationStatus === 'CANCEL_REQUESTED') {
         createToast({
           message: SUCCESS_MESSAGE.EVENT.CANCEL_REQUESTED,
           toastType: 'success',

--- a/src/mocks/data/eventData.ts
+++ b/src/mocks/data/eventData.ts
@@ -1,38 +1,5 @@
 import { AllEventsResponse } from '@/types/api/allEvents';
-import { GetAppliedEventResponse } from '@/types/api/getAppliedEvent';
 import { ShowDetailResponse } from '@/types/api/getEventDetail';
-
-const appliedEvent: GetAppliedEventResponse = {
-  data: [
-    {
-      id: '1',
-      title: 'test1',
-      clubName: 'test',
-      startDate: '2021-10-10',
-      location: 'test',
-      status: 'CANCELED',
-      posterImageUrl:
-        'https://english.seoul.go.kr/wp-content/uploads/2022/09/working-seoul-poster-214x300.jpg',
-    },
-    {
-      id: '2',
-      title: 'test2',
-      clubName: 'test',
-      startDate: '2021-10-10',
-      location: 'test',
-      status: 'CANCELED',
-      posterImageUrl: 'https://www.europosters.ie/image/framed/750/115398_modenacerna.jpg',
-    },
-  ],
-  pageData: {
-    first: true,
-    last: true,
-    pageNumber: 1,
-    size: 10,
-    totalPages: 30,
-    totalElements: 2,
-  },
-};
 
 const allEvents: AllEventsResponse = {
   data: [
@@ -187,4 +154,4 @@ const eventForm = {
   },
 };
 
-export { appliedEvent, allEvents, eventDetail, eventForm };
+export { allEvents, eventDetail, eventForm };

--- a/src/mocks/event.ts
+++ b/src/mocks/event.ts
@@ -2,15 +2,11 @@ import { HttpResponse, http } from 'msw';
 
 import { END_POINTS } from '@constants/api';
 
-import { allEvents, appliedEvent, eventDetail, eventForm } from './data/eventData';
+import { allEvents, eventDetail, eventForm } from './data/eventData';
 
 const eventHandlers = [
   http.post(`${END_POINTS.PERFORMANCE_FORM}`, async () => {
     return HttpResponse.json({ eventId: '1' }, { status: 201 });
-  }),
-
-  http.get(`${END_POINTS.GET_APPLIED_EVENT}?page=$1size=10&sort=id,startDate`, async () => {
-    return HttpResponse.json(appliedEvent, { status: 201 });
   }),
 
   http.get(`${END_POINTS.ALL_EVENTS}?page=1&size=10&sort=id,startDate`, async () => {

--- a/src/pages/ProfilePage/AppliedEvents.tsx
+++ b/src/pages/ProfilePage/AppliedEvents.tsx
@@ -33,7 +33,7 @@ const AppliedEvents = () => {
               startDate={event.startDate}
               location={event.location}
               clubName={event.clubName}
-              eventStatus={event.status}
+              eventStatus={event.participationStatus}
             />
           ))
         ) : (

--- a/src/types/api/cancelEvent.ts
+++ b/src/types/api/cancelEvent.ts
@@ -5,7 +5,7 @@ interface CancelEventRequest {
 }
 
 interface CancelEventResponse {
-  applicationStatus: EventStatus;
+  participationStatus: EventStatus;
 }
 
 export { CancelEventRequest, CancelEventResponse };

--- a/src/types/api/getAppliedEvent.ts
+++ b/src/types/api/getAppliedEvent.ts
@@ -7,7 +7,7 @@ interface GetAppliedEventData {
   clubName: string;
   startDate: string;
   location: string;
-  status: EventStatus;
+  participationStatus: EventStatus;
   posterImageUrl: string;
 }
 


### PR DESCRIPTION
## 📝요구사항과 구현내용
- [ResponseBody 변경]
행사 신청 취소 (applicationStatus -> participationStatus)
유저가 신청한 모든 행사 조회  (status-> participationStatus)

- [API Endpoint 변경]
applications -> participate

- 모킹 데이터 삭제


## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



