### PR TITLE
SKRF-369 design: 행사들 레이아웃 수정

### DIFF
--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -5,7 +5,6 @@ const ContainerStyled = styled.div`
   width: 20.3rem;
   height: 13.3rem;
   cursor: pointer;
-  border: 1px solid;
 `;
 
 const PosterAreaStyled = styled.div`

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -4,15 +4,12 @@ const ContainerStyled = styled.div`
   display: flex;
   width: 20.3rem;
   height: 13.3rem;
-  font-family: 'MainThin';
-  margin-bottom: 5%;
   cursor: pointer;
+  border: 1px solid;
 `;
 
 const PosterAreaStyled = styled.div`
   display: flex;
-  justify-content: center;
-  align-items: center;
   object-fit: cover;
 `;
 

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -25,13 +25,13 @@ const END_POINTS = {
     category: string;
     pageNumber: number;
     sort: string;
-  }) => `events?category=${category}&page=${pageNumber}&size=18&sort=${sort},desc`,
+  }) => `events?category=${category}&page=${pageNumber}&size=12&sort=${sort},desc`,
   EVENT_APPLY: '/events/participate',
   CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/participate`,
   GET_SUBMITTED_FORMS: ({ eventId, pageNumber }: { eventId: string; pageNumber: number }) =>
     `events/${eventId}/forms/submit?page=${pageNumber}&size=20&sort=id,desc`,
   SEARCHES: ({ keyword, page }: { keyword: string; page: number }) =>
-    `/events/searches?keyword=${keyword}&page=${page}&size=18&sort=id,desc`,
+    `/events/searches?keyword=${keyword}&page=${page}&size=12&sort=id,desc`,
   SUBMITTED_FORM_STATUS: ({ eventId }: { eventId: string }) => `/events/${eventId}/forms/submit`,
 
   CREATE_CLUB: '/clubs',
@@ -41,7 +41,7 @@ const END_POINTS = {
   INVITE_CLUB_CODE: (inviteCode: string) => `/clubs/invites/${inviteCode}`,
   CLUB_MEMBERS: (clubId: string) => `/clubs/${clubId}/members`,
   CLUB_EVENTS: ({ clubId, pageNumber }: { clubId: string; pageNumber: number }) =>
-    `/clubs/${clubId}/events?page=${pageNumber}&size=18&sort=id,desc`,
+    `/clubs/${clubId}/events?page=${pageNumber}&size=12&sort=id,desc`,
   PATCH_MEMBER_ROLE: ({ clubId, memberId }: { clubId: string; memberId: string }) =>
     `/clubs/${clubId}/members/${memberId}`,
   EDIT_CLUB_SETTING: ({ clubId }: { clubId: string }) => `/clubs/${clubId}`,

--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -10,14 +10,16 @@ const BannerWrapperStyled = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 5% 0;
+  margin: 2rem;
 `;
 
 const EventCardWrapperStyled = styled.div`
   display: flex;
+  justify-content: space-evenly;
   flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 5%;
+  gap: 1rem;
+  max-width: 70rem;
+  width: fit-content;
 `;
 
 const PaginationWrapper = styled.div`

--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -14,11 +14,20 @@ const BannerWrapperStyled = styled.div`
 `;
 
 const EventCardWrapperStyled = styled.div`
-  display: flex;
-  justify-content: space-evenly;
-  flex-wrap: wrap;
-  gap: 1rem;
-  max-width: 70rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 1rem;
+  justify-items: center;
+  align-items: center;
+  max-width: 75rem;
+
+  @media (max-width: 71rem) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (max-width: 50rem) {
+    grid-template-columns: 1fr;
+  }
 `;
 
 const PaginationWrapper = styled.div`

--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -13,25 +13,8 @@ const BannerWrapperStyled = styled.div`
   margin: 2rem;
 `;
 
-const EventCardWrapperStyled = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 1rem;
-  justify-items: center;
-  align-items: center;
-  max-width: 75rem;
-
-  @media (max-width: 71rem) {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  @media (max-width: 50rem) {
-    grid-template-columns: 1fr;
-  }
-`;
-
 const PaginationWrapper = styled.div`
   padding: 2rem 0 5rem 0;
 `;
 
-export { ContentContainerStyled, BannerWrapperStyled, EventCardWrapperStyled, PaginationWrapper };
+export { ContentContainerStyled, BannerWrapperStyled, PaginationWrapper };

--- a/src/pages/MainPage/MainPage.style.ts
+++ b/src/pages/MainPage/MainPage.style.ts
@@ -19,7 +19,6 @@ const EventCardWrapperStyled = styled.div`
   flex-wrap: wrap;
   gap: 1rem;
   max-width: 70rem;
-  width: fit-content;
 `;
 
 const PaginationWrapper = styled.div`

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -6,16 +6,12 @@ import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
 import useAllEventsQuery from '@/hooks/query/event/useAllEventsQuery';
+import { EventsWrapper } from '@/styles/common';
 
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import {
-  BannerWrapperStyled,
-  ContentContainerStyled,
-  EventCardWrapperStyled,
-  PaginationWrapper,
-} from './MainPage.style';
+import { BannerWrapperStyled, ContentContainerStyled, PaginationWrapper } from './MainPage.style';
 
 const MainPage = () => {
   const { pathname } = useLocation();
@@ -53,7 +49,7 @@ const MainPage = () => {
         <BannerWrapperStyled>
           <Banner width={35} height={20} />
         </BannerWrapperStyled>
-        <EventCardWrapperStyled>
+        <EventsWrapper>
           {events?.map(({ id, eventInfo, formInfo, clubInfo }) => {
             return (
               <EventCard
@@ -68,7 +64,7 @@ const MainPage = () => {
               />
             );
           })}
-        </EventCardWrapperStyled>
+        </EventsWrapper>
         <PaginationWrapper>
           <Pagination totalPages={totalPages} size={size} onChangePage={handleChangePage} />
         </PaginationWrapper>

--- a/src/pages/SearchResultPage/SearchResultPage.style.ts
+++ b/src/pages/SearchResultPage/SearchResultPage.style.ts
@@ -16,8 +16,9 @@ const SearchMessageStyled = styled.div`
 const SearchesWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 5%;
+  justify-content: space-evenly;
+  gap: 1rem;
+  max-width: 70rem;
 `;
 
 const PaginationWrapper = styled.div`

--- a/src/pages/SearchResultPage/SearchResultPage.style.ts
+++ b/src/pages/SearchResultPage/SearchResultPage.style.ts
@@ -13,16 +13,8 @@ const SearchMessageStyled = styled.div`
   font-size: ${Theme.fontSize.smallTitle};
 `;
 
-const SearchesWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-evenly;
-  gap: 1rem;
-  max-width: 70rem;
-`;
-
 const PaginationWrapper = styled.div`
   padding: 2rem 0 5rem 0;
 `;
 
-export { SearchesContainer, SearchMessageStyled, SearchesWrapper, PaginationWrapper };
+export { SearchesContainer, SearchMessageStyled, PaginationWrapper };

--- a/src/pages/SearchResultPage/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage/SearchResultPage.tsx
@@ -5,6 +5,7 @@ import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
 import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
+import { EventsWrapper } from '@/styles/common';
 
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
@@ -13,7 +14,6 @@ import {
   PaginationWrapper,
   SearchMessageStyled,
   SearchesContainer,
-  SearchesWrapper,
 } from './SearchResultPage.style';
 
 const SearchResultPage = () => {
@@ -33,7 +33,7 @@ const SearchResultPage = () => {
       </Header>
       <SearchMessageStyled>{`"${keyword}" 검색 결과`}</SearchMessageStyled>
       <SearchesContainer>
-        <SearchesWrapper>
+        <EventsWrapper>
           {data?.map((event) => (
             <EventCard
               key={event.id}
@@ -47,7 +47,7 @@ const SearchResultPage = () => {
               clubImageSrc={event.clubInfo.logoImageUrl}
             />
           ))}
-        </SearchesWrapper>
+        </EventsWrapper>
         <PaginationWrapper>
           <Pagination
             totalPages={totalPages}

--- a/src/pages/club/ClubEventPage/ClubEventPage.style.ts
+++ b/src/pages/club/ClubEventPage/ClubEventPage.style.ts
@@ -1,15 +1,6 @@
 import Theme from '@/styles/Theme';
 import styled from '@emotion/styled';
 
-const EventsContainer = styled.div`
-  display: flex;
-  justify-content: space-evenly;
-  flex-wrap: wrap;
-  gap: 1rem;
-  max-width: 70rem;
-  padding-top: 3rem;
-`;
-
 const EmptyClubEvent = styled.div`
   display: flex;
   justify-content: center;
@@ -25,4 +16,4 @@ const ButtonWrapper = styled.div`
   right: 5rem;
 `;
 
-export { EventsContainer, ButtonWrapper, EmptyClubEvent };
+export { ButtonWrapper, EmptyClubEvent };

--- a/src/pages/club/ClubEventPage/ClubEventPage.style.ts
+++ b/src/pages/club/ClubEventPage/ClubEventPage.style.ts
@@ -3,9 +3,10 @@ import styled from '@emotion/styled';
 
 const EventsContainer = styled.div`
   display: flex;
-  justify-content: center;
-  align-items: center;
+  justify-content: space-evenly;
   flex-wrap: wrap;
+  gap: 1rem;
+  max-width: 70rem;
   padding-top: 3rem;
 `;
 

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -5,11 +5,12 @@ import Pagination from '@/components/common/Pagination/Pagination';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
 import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
+import { EventsWrapper } from '@/styles/common';
 
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { ButtonWrapper, EmptyClubEvent, EventsContainer } from './ClubEventPage.style';
+import { ButtonWrapper, EmptyClubEvent } from './ClubEventPage.style';
 
 const ClubEventPage = () => {
   const navigate = useNavigate();
@@ -30,7 +31,7 @@ const ClubEventPage = () => {
   return (
     <>
       <ClubHeader clubId={clubId}></ClubHeader>
-      <EventsContainer>
+      <EventsWrapper>
         {clubEvents?.map(({ id, eventInfo, formInfo, clubInfo }) => (
           <EventCard
             eventId={id}
@@ -47,7 +48,7 @@ const ClubEventPage = () => {
         {clubEvents?.length === 0 && (
           <EmptyClubEvent>클럽에서 생성한 행사가 없습니다!</EmptyClubEvent>
         )}
-      </EventsContainer>
+      </EventsWrapper>
       <Pagination totalPages={totalPages} size={size} onChangePage={handleChangePage} />
       <ButtonWrapper>
         <ActiveButton

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -84,6 +84,23 @@ const TabWrapper = styled.div`
   width: 100%;
 `;
 
+const EventsWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 1rem;
+  justify-items: center;
+  align-items: center;
+  max-width: 75rem;
+
+  @media (max-width: 71rem) {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  @media (max-width: 50rem) {
+    grid-template-columns: 1fr;
+  }
+`;
+
 const sideBarScrollAreaStyled = styled.div`
   &::-webkit-scrollbar {
     width: 0.3rem;
@@ -162,4 +179,5 @@ export {
   TabWrapper,
   SmallTitleStyled,
   hoverBox,
+  EventsWrapper,
 };


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 메인페이지, 클럽행사 페이지, 검색결과 페이지의 행사들 정렬 레이아웃을 grid로 수정했습니다. 이때 한 줄에 최대 3개만 보이도록 설정했습니다. 포스터 옆에 행사 정보도 적혀 있어서, 한 줄에 여러 개의 행사들이 들어가게 되니 산만해 보였기 때문입니다!
- 각 행사들은 한 페이지에 최대 12개씩 보여집니다. 12개인 이유는... 페이지가 2 이상이라면 화면을 좁혔을 때 grid의 칸이 비는 것이 어색해 보이기 때문입니다. 한 줄에 최대 3개씩 들어가므로 12개라면 그리드가 깨지지 않습니다!

## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



