### PR TITLE
SKRF-390 fix: club events page

### DIFF
--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -23,12 +23,6 @@ const EventInfoWrapper = styled.div`
   word-break: break-all;
 `;
 
-const TitleStyled = styled.div`
-  padding-bottom: 3%;
-  font-family: 'MainBold';
-  font-size: 1.5rem;
-`;
-
 const EventDateStyled = styled.div`
   padding-bottom: 2%;
   font-size: 1rem;
@@ -67,7 +61,6 @@ export {
   ContainerStyled,
   PosterAreaStyled,
   EventInfoWrapper,
-  TitleStyled,
   EventDateStyled,
   EventTimeStyled,
   EventFooterWrapper,

--- a/src/components/common/EventCard/EventCard.style.ts
+++ b/src/components/common/EventCard/EventCard.style.ts
@@ -43,7 +43,7 @@ const EventFooterWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  height: 20%;
+  height: 23%;
   margin-right: 3%;
 `;
 

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -56,7 +56,9 @@ const EventCard = ({
       <EventInfoWrapper>
         <div>
           <EventTitleStyled>{eventTitle}</EventTitleStyled>
-          <EventDateStyled>{endDate ? `~${endDate}` : startDate ? startDate : ''}</EventDateStyled>
+          <EventDateStyled>
+            {endDate ? `마감: ${endDate}` : startDate ? startDate : ''}
+          </EventDateStyled>
         </div>
         <EventFooterWrapper>
           <PlaceStyled>{location}</PlaceStyled>

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -1,5 +1,6 @@
 import { APPLIED_EVENTS_TAGS } from '@/constants/event';
 import { PATH } from '@/constants/path';
+import { EventTitleStyled } from '@/styles/common';
 
 import { useNavigate } from 'react-router-dom';
 
@@ -14,7 +15,6 @@ import {
   EventFooterWrapper,
   EventInfoWrapper,
   PlaceStyled,
-  TitleStyled,
 } from './EventCard.style';
 
 interface EventProps {
@@ -55,7 +55,7 @@ const EventCard = ({
       </Poster>
       <EventInfoWrapper>
         <div>
-          <TitleStyled>{eventTitle}</TitleStyled>
+          <EventTitleStyled>{eventTitle}</EventTitleStyled>
           <EventDateStyled>{endDate ? `~${endDate}` : startDate ? startDate : ''}</EventDateStyled>
         </div>
         <EventFooterWrapper>

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -25,13 +25,13 @@ const END_POINTS = {
     category: string;
     pageNumber: number;
     sort: string;
-  }) => `events?category=${category}&page=${pageNumber}&size=12&sort=${sort},desc`,
+  }) => `events?category=${category}&page=${pageNumber}&size=12&sort=${sort},asc`,
   EVENT_APPLY: '/events/participate',
   CANCEL_EVENT: ({ eventId }: { eventId: string }) => `/events/${eventId}/participate`,
   GET_SUBMITTED_FORMS: ({ eventId, pageNumber }: { eventId: string; pageNumber: number }) =>
     `events/${eventId}/forms/submit?page=${pageNumber}&size=20&sort=id,desc`,
   SEARCHES: ({ keyword, page }: { keyword: string; page: number }) =>
-    `/events/searches?keyword=${keyword}&page=${page}&size=12&sort=id,desc`,
+    `/events/searches?keyword=${keyword}&page=${page}&size=12&sort=id,asc`,
   SUBMITTED_FORM_STATUS: ({ eventId }: { eventId: string }) => `/events/${eventId}/forms/submit`,
 
   CREATE_CLUB: '/clubs',
@@ -41,7 +41,7 @@ const END_POINTS = {
   INVITE_CLUB_CODE: (inviteCode: string) => `/clubs/invites/${inviteCode}`,
   CLUB_MEMBERS: (clubId: string) => `/clubs/${clubId}/members`,
   CLUB_EVENTS: ({ clubId, pageNumber }: { clubId: string; pageNumber: number }) =>
-    `/clubs/${clubId}/events?page=${pageNumber}&size=12&sort=id,desc`,
+    `/clubs/${clubId}/events?page=${pageNumber}&size=12&sort=id,asc`,
   PATCH_MEMBER_ROLE: ({ clubId, memberId }: { clubId: string; memberId: string }) =>
     `/clubs/${clubId}/members/${memberId}`,
   EDIT_CLUB_SETTING: ({ clubId }: { clubId: string }) => `/clubs/${clubId}`,

--- a/src/pages/club/ClubEventPage/ClubEventPage.style.ts
+++ b/src/pages/club/ClubEventPage/ClubEventPage.style.ts
@@ -5,12 +5,20 @@ const ContentSpacer = styled.div`
   height: 1.3rem;
 `;
 
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+`;
+
 const EmptyClubEvent = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 50vh;
-  color: ${Theme.color.semiBlack};
+  width: 100%;
+  height: 60vh;
   font-size: ${Theme.fontSize.mediumContent};
 `;
 
@@ -20,4 +28,4 @@ const ButtonWrapper = styled.div`
   right: 5rem;
 `;
 
-export { ContentSpacer, ButtonWrapper, EmptyClubEvent };
+export { ContentContainer, ContentSpacer, ButtonWrapper, EmptyClubEvent };

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -5,12 +5,17 @@ import Pagination from '@/components/common/Pagination/Pagination';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
 import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
-import { EventsWrapper } from '@/styles/common';
+import { CommonEmptyEventsWrapper, EventsWrapper } from '@/styles/common';
 
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { ButtonWrapper, ContentSpacer, EmptyClubEvent } from './ClubEventPage.style';
+import {
+  ButtonWrapper,
+  ContentContainer,
+  ContentSpacer,
+  EmptyClubEvent,
+} from './ClubEventPage.style';
 
 const ClubEventPage = () => {
   const navigate = useNavigate();
@@ -32,27 +37,31 @@ const ClubEventPage = () => {
     <>
       <ClubHeader clubId={clubId}></ClubHeader>
       <ContentSpacer />
-      <EventsWrapper>
-        {clubEvents?.map(({ id, eventInfo, clubInfo }) => (
-          <EventCard
-            key={id}
-            eventId={id}
-            posterSrc={eventInfo.posterImageUrl}
-            eventTitle={eventInfo.title}
-            startDate={eventInfo.startDate}
-            endDate={eventInfo.endDate}
-            location={eventInfo.location}
-            clubLogoImageUrl={clubInfo.logoImageUrl}
-            clubName={clubInfo.name}
-            openStatus={eventInfo.openStatus}
-            isEnded={eventInfo.isEnded}
-          />
-        ))}
+      <ContentContainer>
+        <EventsWrapper>
+          {clubEvents?.map(({ id, eventInfo, clubInfo }) => (
+            <EventCard
+              key={id}
+              eventId={id}
+              posterSrc={eventInfo.posterImageUrl}
+              eventTitle={eventInfo.title}
+              startDate={eventInfo.startDate}
+              endDate={eventInfo.endDate}
+              location={eventInfo.location}
+              clubLogoImageUrl={clubInfo.logoImageUrl}
+              clubName={clubInfo.name}
+              openStatus={eventInfo.openStatus}
+              isEnded={eventInfo.isEnded}
+            />
+          ))}
+        </EventsWrapper>
         {clubEvents?.length === 0 && (
-          <EmptyClubEvent>클럽에서 생성한 행사가 없습니다!</EmptyClubEvent>
+          <CommonEmptyEventsWrapper>
+            <EmptyClubEvent>클럽에서 생성한 행사가 없습니다!</EmptyClubEvent>
+          </CommonEmptyEventsWrapper>
         )}
-      </EventsWrapper>
-      <Pagination totalPages={totalPages} size={size} onChangePage={handleChangePage} />
+        <Pagination totalPages={totalPages} size={size} onChangePage={handleChangePage} />
+      </ContentContainer>
       <ButtonWrapper>
         <ActiveButton
           buttonText={CREATE_EVENT.BUTTON_TEXT}

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -101,6 +101,14 @@ const EventsWrapper = styled.div`
   }
 `;
 
+const CommonEmptyEventsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  color: ${Theme.color.gray};
+`;
+
 const sideBarScrollAreaStyled = styled.div`
   &::-webkit-scrollbar {
     width: 0.3rem;
@@ -180,4 +188,5 @@ export {
   SmallTitleStyled,
   hoverBox,
   EventsWrapper,
+  CommonEmptyEventsWrapper,
 };


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 클럽 행사 비어 있을 때 메시지 중앙처리하기
- 클럽 행사 페이지네이션 하단에 위치하게 하기
- 이벤트카드 제목 두 줄 이상 ellipsis처리
- 이벤트 카드 장소와 클럽 명 사이 공간 주기
- 마감일 있는 경우 ‘마감: 날짜’로 보여주기
- 클럽 행사 정렬 수정하기

## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



