### PR TITLE
SKRF-417 fix: 행사정보작성페이지 QA

### DIFF
--- a/src/components/ClassificationCard/ClassificationCard.style.ts
+++ b/src/components/ClassificationCard/ClassificationCard.style.ts
@@ -13,7 +13,7 @@ const CardContainer = styled.div<{ backColor: string }>`
   transition: transform 0.2s;
 
   &:hover {
-    transform: scale(1.1);
+    transform: scale(1.05);
   }
 `;
 const Wrapper = styled.div<{ img: string }>`

--- a/src/components/ImageForm/ImageForm.style.ts
+++ b/src/components/ImageForm/ImageForm.style.ts
@@ -20,6 +20,7 @@ const ImageWrapper = styled.div`
 const PreviewImage = styled.img`
   width: 100%;
   height: 100%;
+  object-fit: cover;
 `;
 const ImageLabelStyled = styled.label`
   position: absolute;

--- a/src/components/common/InputForm/InputForm.style.ts
+++ b/src/components/common/InputForm/InputForm.style.ts
@@ -24,9 +24,9 @@ const InputStyled = styled.input`
   height: 3rem;
   outline: none;
   margin-top: 0.5rem;
+  padding: 0 1rem;
   border: 1px solid ${Theme.color.tLine};
   border-radius: 1rem;
-  padding-left: 1rem;
   box-sizing: border-box;
 
   :disabled {
@@ -43,6 +43,10 @@ const InputStyled = styled.input`
     position: absolute;
     width: 100%;
     cursor: pointer;
+  }
+
+  &[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
   }
 `;
 

--- a/src/components/common/InputForm/InputForm.style.ts
+++ b/src/components/common/InputForm/InputForm.style.ts
@@ -1,7 +1,7 @@
 import Theme from '@/styles/Theme';
 import styled from '@emotion/styled';
 
-const InputWrapper = styled.div`
+const InputContainer = styled.div`
   width: 100%;
 `;
 const LabelStyled = styled.label`
@@ -17,6 +17,9 @@ const RequiredSquare = styled.span`
   height: 0.3rem;
   background-color: ${Theme.color.tButton};
   border-radius: 50%;
+`;
+const InputWrapper = styled.div`
+  position: relative;
 `;
 const InputStyled = styled.input`
   position: relative;
@@ -45,9 +48,20 @@ const InputStyled = styled.input`
     cursor: pointer;
   }
 
+  &[type='number'] {
+    padding-right: 2rem;
+  }
+
   &[type='number']::-webkit-inner-spin-button {
     -webkit-appearance: none;
   }
 `;
+const InputUnit = styled.span<{ isHalf?: boolean }>`
+  position: absolute;
+  top: calc(50% - 0.3rem);
+  right: ${({ isHalf }) => (isHalf ? 'calc(50% + 1rem)' : '1rem')};
+  font-size: 0.8rem;
+  color: ${Theme.color.semiBlack};
+`;
 
-export { InputWrapper, LabelStyled, RequiredSquare, InputStyled };
+export { InputContainer, LabelStyled, RequiredSquare, InputWrapper, InputStyled, InputUnit };

--- a/src/components/common/InputForm/InputForm.tsx
+++ b/src/components/common/InputForm/InputForm.tsx
@@ -1,6 +1,13 @@
 import { forwardRef } from 'react';
 
-import { InputStyled, InputWrapper, LabelStyled, RequiredSquare } from './InputForm.style';
+import {
+  InputContainer,
+  InputStyled,
+  InputUnit,
+  InputWrapper,
+  LabelStyled,
+  RequiredSquare,
+} from './InputForm.style';
 
 interface InputForm extends React.InputHTMLAttributes<HTMLInputElement> {
   labelText?: string;
@@ -9,30 +16,45 @@ interface InputForm extends React.InputHTMLAttributes<HTMLInputElement> {
   placeholder?: string;
   maxLength?: number;
   containerWidth?: string | number;
+  unit?: '명' | '원' | '매';
+  isHalf?: boolean;
 }
 
 const InputForm = forwardRef<HTMLInputElement, InputForm>(
   (
-    { labelText, required = false, inputType, placeholder, maxLength, containerWidth, ...props },
+    {
+      labelText,
+      required = false,
+      inputType,
+      placeholder,
+      maxLength,
+      containerWidth,
+      unit,
+      isHalf,
+      ...props
+    },
     ref,
   ) => {
     return (
-      <InputWrapper style={{ width: containerWidth }}>
+      <InputContainer style={{ width: containerWidth }}>
         {labelText && (
           <LabelStyled htmlFor={labelText}>
             {labelText}
             {required && <RequiredSquare />}
           </LabelStyled>
         )}
-        <InputStyled
-          id={labelText}
-          type={inputType}
-          ref={ref}
-          maxLength={maxLength}
-          placeholder={placeholder}
-          {...props}
-        />
-      </InputWrapper>
+        <InputWrapper style={{ display: 'flex', position: 'relative' }}>
+          <InputStyled
+            id={labelText}
+            type={inputType}
+            ref={ref}
+            maxLength={maxLength}
+            placeholder={placeholder}
+            {...props}
+          />
+          {unit && <InputUnit isHalf={!!isHalf}>{unit}</InputUnit>}
+        </InputWrapper>
+      </InputContainer>
     );
   },
 );

--- a/src/components/common/InputForm/InputForm.tsx
+++ b/src/components/common/InputForm/InputForm.tsx
@@ -35,6 +35,11 @@ const InputForm = forwardRef<HTMLInputElement, InputForm>(
     },
     ref,
   ) => {
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (inputType === 'datetime-local') {
+        event.preventDefault();
+      }
+    };
     return (
       <InputContainer style={{ width: containerWidth }}>
         {labelText && (
@@ -50,6 +55,7 @@ const InputForm = forwardRef<HTMLInputElement, InputForm>(
             ref={ref}
             maxLength={maxLength}
             placeholder={placeholder}
+            onKeyDown={handleKeyDown}
             {...props}
           />
           {unit && <InputUnit isHalf={!!isHalf}>{unit}</InputUnit>}

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -42,6 +42,7 @@ const ERROR_MESSAGE = {
 
   COMMON: {
     CURRENT_REF_ERROR: '할당된 current ref가 없습니다',
+    TRIM: '공백으로만 이루어질 수 없습니다.',
   },
 } as const;
 

--- a/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
@@ -93,6 +93,8 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
             labelText="정원"
             inputType="number"
             placeholder="정수(1-n)"
+            min={LIMIT_VALUE.CAPACITY_MIN}
+            max={LIMIT_VALUE.CAPACITY_MAX}
           />
           <InputForm
             {...register('cost', {
@@ -102,6 +104,8 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
             labelText="비용"
             inputType="number"
             placeholder="정수(0-n)"
+            min={LIMIT_VALUE.CAPACITY_MIN}
+            max={LIMIT_VALUE.CAPACITY_MAX}
           />
         </TwoInputContainer>
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
@@ -140,6 +144,8 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
           labelText="인당 예매 가능 수"
           inputType="number"
           placeholder="정수(1-n)"
+          min={LIMIT_VALUE.TICKET_COUNT_MIN}
+          max={LIMIT_VALUE.TICKET_COUNT_MAX}
         />
         {errors.maxTicketCount && (
           <ErrorMessage>{errors.maxTicketCount.message as string}</ErrorMessage>

--- a/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
@@ -95,6 +95,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
             placeholder="정수(1-n)"
             min={LIMIT_VALUE.CAPACITY_MIN}
             max={LIMIT_VALUE.CAPACITY_MAX}
+            unit="명"
           />
           <InputForm
             {...register('cost', {
@@ -106,6 +107,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
             placeholder="정수(0-n)"
             min={LIMIT_VALUE.CAPACITY_MIN}
             max={LIMIT_VALUE.CAPACITY_MAX}
+            unit="원"
           />
         </TwoInputContainer>
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
@@ -146,6 +148,8 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
           placeholder="정수(1-n)"
           min={LIMIT_VALUE.TICKET_COUNT_MIN}
           max={LIMIT_VALUE.TICKET_COUNT_MAX}
+          unit="매"
+          isHalf={true}
         />
         {errors.maxTicketCount && (
           <ErrorMessage>{errors.maxTicketCount.message as string}</ErrorMessage>

--- a/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PerformanceForm/PerformanceForm.tsx
@@ -5,7 +5,7 @@ import { FORM_INFO_VALUE } from '@/constants/limitInputValue';
 import { ShowDetailResponse } from '@/types/api/getEventDetail';
 import { ReactHookFormProps } from '@/types/event';
 import setFormValue from '@/utils/setFormValue';
-import { validateTimeCompare, validateTodayDate } from '@/utils/validate';
+import { validateTimeCompare, validateTodayDate, validateTrim } from '@/utils/validate';
 
 import { useEffect } from 'react';
 
@@ -50,6 +50,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
               value: LIMIT_LENGTH.TITLE_MAX,
               message: MAX_LENGTH('공연 이름', LIMIT_LENGTH.TAGET_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="공연 이름"
           required
@@ -78,6 +79,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
               value: LIMIT_LENGTH.LOCATION_MAX,
               message: MAX_LENGTH('공연 장소', LIMIT_LENGTH.LOCATION_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="공연 장소"
           required
@@ -119,6 +121,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
                 value: LIMIT_LENGTH.BANK_NAME_MAX,
                 message: MAX_LENGTH('은행 이름', LIMIT_LENGTH.BANK_NAME_MAX),
               },
+              validate: (value) => validateTrim(value),
             })}
             labelText="은행 명"
             inputType="text"
@@ -130,6 +133,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
                 value: LIMIT_LENGTH.ACCOUNT_NUMBER_MAX,
                 message: MAX_LENGTH('계좌 번호', LIMIT_LENGTH.ACCOUNT_NUMBER_MAX),
               },
+              validate: (value) => validateTrim(value),
             })}
             labelText="계좌 번호"
             inputType="text"
@@ -137,7 +141,9 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
           />
         </TwoInputContainer>
         {errors.bankName && <ErrorMessage>{errors.bankName.message as string}</ErrorMessage>}
-        {errors.account && <ErrorMessage>{errors.account.message as string}</ErrorMessage>}
+        {errors.accountNumber && (
+          <ErrorMessage>{errors.accountNumber.message as string}</ErrorMessage>
+        )}
         <HalfInputForm
           {...register('maxTicketCount', {
             min: { value: LIMIT_VALUE.TICKET_COUNT_MIN, message: `${TICKET}` },
@@ -201,6 +207,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
               value: LIMIT_LENGTH.CONTENT_MAX,
               message: MAX_LENGTH('공연 내용', LIMIT_LENGTH.CONTENT_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="공연 내용 작성"
           required

--- a/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
@@ -89,6 +89,8 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
           labelText="정원"
           inputType="number"
           placeholder="정수(0-n)"
+          min={LIMIT_VALUE.CAPACITY_MIN}
+          max={LIMIT_VALUE.CAPACITY_MAX}
         />
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
         <TwoInputContainer>

--- a/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
@@ -91,6 +91,8 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
           placeholder="정수(0-n)"
           min={LIMIT_VALUE.CAPACITY_MIN}
           max={LIMIT_VALUE.CAPACITY_MAX}
+          unit="명"
+          isHalf={true}
         />
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
         <TwoInputContainer>

--- a/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/PromotionForm/PromotionForm.tsx
@@ -5,7 +5,7 @@ import { FORM_INFO_VALUE } from '@/constants/limitInputValue';
 import { PromotionDetailResponse } from '@/types/api/getEventDetail';
 import { ReactHookFormProps } from '@/types/event';
 import setFormValue from '@/utils/setFormValue';
-import { validateTimeCompare, validateTodayDate } from '@/utils/validate';
+import { validateTimeCompare, validateTodayDate, validateTrim } from '@/utils/validate';
 
 import { useEffect } from 'react';
 
@@ -46,6 +46,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
               value: LIMIT_LENGTH.TITLE_MAX,
               message: MAX_LENGTH('행사 이름', LIMIT_LENGTH.TITLE_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="행사 이름"
           required
@@ -75,6 +76,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
               value: LIMIT_LENGTH.LOCATION_MAX,
               message: MAX_LENGTH('행사 장소', LIMIT_LENGTH.LOCATION_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="행사 장소"
           required
@@ -142,6 +144,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
               value: LIMIT_LENGTH.CONTENT_MAX,
               message: MAX_LENGTH('행사 내용', LIMIT_LENGTH.CONTENT_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="행사 내용 작성"
           required

--- a/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
@@ -87,6 +87,8 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
           labelText="모집 인원"
           inputType="number"
           placeholder="정수(1-n)"
+          min={LIMIT_VALUE.CAPACITY_MIN}
+          max={LIMIT_VALUE.CAPACITY_MAX}
         />
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
         <TwoInputContainer>

--- a/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
@@ -5,7 +5,7 @@ import { FORM_INFO_VALUE } from '@/constants/limitInputValue';
 import { RecruitmentDetailResponse } from '@/types/api/getEventDetail';
 import { ReactHookFormProps } from '@/types/event';
 import setFormValue from '@/utils/setFormValue';
-import { validateTimeCompare, validateTodayDate } from '@/utils/validate';
+import { validateTimeCompare, validateTodayDate, validateTrim } from '@/utils/validate';
 
 import { useEffect } from 'react';
 
@@ -45,6 +45,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
               value: LIMIT_LENGTH.TITLE_MAX,
               message: MAX_LENGTH('공고 제목', LIMIT_LENGTH.TITLE_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="공고 제목"
           required
@@ -58,6 +59,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
               value: LIMIT_LENGTH.LOCATION_MAX,
               message: MAX_LENGTH('활동 위치', LIMIT_LENGTH.LOCATION_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="활동 위치"
           inputType="text"
@@ -72,6 +74,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
               value: LIMIT_LENGTH.TAGET_MAX,
               message: MAX_LENGTH('모집 대상', LIMIT_LENGTH.TAGET_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="모집 대상"
           rows={2}
@@ -140,6 +143,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
               value: LIMIT_LENGTH.CONTENT_MAX,
               message: MAX_LENGTH('공고 내용', LIMIT_LENGTH.CONTENT_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="공고 내용"
           required

--- a/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/RecruitForm/RecruitForm.tsx
@@ -89,6 +89,8 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
           placeholder="정수(1-n)"
           min={LIMIT_VALUE.CAPACITY_MIN}
           max={LIMIT_VALUE.CAPACITY_MAX}
+          unit="명"
+          isHalf={true}
         />
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}
         <TwoInputContainer>

--- a/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
@@ -115,6 +115,8 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             labelText="정원"
             inputType="number"
             placeholder="정수(1-n)"
+            min={LIMIT_VALUE.CAPACITY_MIN}
+            max={LIMIT_VALUE.CAPACITY_MAX}
           />
           <InputForm
             {...register('dues', {
@@ -124,6 +126,8 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             labelText="회비"
             inputType="number"
             placeholder="정수(0-n)"
+            min={LIMIT_VALUE.COST_MIN}
+            max={LIMIT_VALUE.COST_MAX}
           />
         </TwoInputContainer>
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}

--- a/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
@@ -28,21 +28,10 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
     }
   }, [eventDetail, setValue]);
 
-  const {
-    PERSONNEL,
-    COST,
-    ENTER_BOTH_SIDE,
-    MAX_YEAR,
-    REQUIRED,
-    MAX_LENGTH,
-    FORM_START_TIME,
-    LAST_TIME,
-  } = ERROR_MESSAGE.EVENT;
+  const { PERSONNEL, COST, MAX_YEAR, REQUIRED, MAX_LENGTH, FORM_START_TIME, LAST_TIME } =
+    ERROR_MESSAGE.EVENT;
 
   const { LIMIT_LENGTH, LIMIT_VALUE } = FORM_INFO_VALUE;
-
-  const openDate = watch('openDate');
-  const closeDate = watch('closeDate');
 
   return (
     <>
@@ -139,7 +128,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
         <TwoInputContainer>
           <InputForm
             {...register('openDate', {
-              required: closeDate && ENTER_BOTH_SIDE,
+              required: REQUIRED('신청 시작 날짜는'),
               validate: {
                 today: validateTodayDate,
                 compare: (value) => validateTimeCompare(value, watch('closeDate'), LAST_TIME),
@@ -147,16 +136,18 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },
             })}
             labelText="신청 시작 날짜 및 시간"
+            required
             inputType="datetime-local"
             containerWidth="50%"
           />
           <InputForm
             {...register('closeDate', {
-              required: openDate && ENTER_BOTH_SIDE,
+              required: REQUIRED('마감 시작 날짜는'),
               validate: (value) => validateTimeCompare(watch('openDate'), value, LAST_TIME),
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },
             })}
             labelText="마감 시작 날짜 및 시간"
+            required
             inputType="datetime-local"
             containerWidth="50%"
           />

--- a/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
@@ -117,6 +117,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             placeholder="정수(1-n)"
             min={LIMIT_VALUE.CAPACITY_MIN}
             max={LIMIT_VALUE.CAPACITY_MAX}
+            unit="명"
           />
           <InputForm
             {...register('dues', {
@@ -128,6 +129,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             placeholder="정수(0-n)"
             min={LIMIT_VALUE.COST_MIN}
             max={LIMIT_VALUE.COST_MAX}
+            unit="원"
           />
         </TwoInputContainer>
         {errors.capacity && <ErrorMessage>{errors.capacity.message as string}</ErrorMessage>}

--- a/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
+++ b/src/pages/event/WriteEventInfoPage/ScheduleForm/ScheduleForm.tsx
@@ -5,7 +5,7 @@ import { FORM_INFO_VALUE } from '@/constants/limitInputValue';
 import { ClubDetailResponse } from '@/types/api/getEventDetail';
 import { ReactHookFormProps } from '@/types/event';
 import setFormValue from '@/utils/setFormValue';
-import { validateTimeCompare, validateTodayDate } from '@/utils/validate';
+import { validateTimeCompare, validateTodayDate, validateTrim } from '@/utils/validate';
 
 import { useEffect } from 'react';
 
@@ -54,6 +54,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
               value: LIMIT_LENGTH.TITLE_MAX,
               message: MAX_LENGTH('일정 제목', LIMIT_LENGTH.TITLE_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="일정 제목"
           required
@@ -102,6 +103,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
               value: LIMIT_LENGTH.LOCATION_MAX,
               message: MAX_LENGTH('장소', LIMIT_LENGTH.LOCATION_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="장소"
           inputType="text"
@@ -178,6 +180,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
               value: LIMIT_LENGTH.CONTENT_MAX,
               message: MAX_LENGTH('일정 안내', LIMIT_LENGTH.CONTENT_MAX),
             },
+            validate: (value) => validateTrim(value),
           })}
           labelText="일정 안내"
           rows={10}

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -16,7 +16,7 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
     ...(eventId ? { eventId } : { clubId }),
     eventInfo: {
       title,
-      content: content.trim(),
+      content: content.trim() || null,
       capacity: parseInt(capacity),
     },
     formInfo: {
@@ -35,15 +35,15 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
           ...commonData.eventInfo,
           startDate: data.startDate.split('T')[0],
           startTime: data.startDate.split('T')[1],
-          location: data.location,
+          location: data.location || null,
         },
         ticketInfo: {
           cost: parseInt(data.cost),
           maxTicketCount: parseInt(data.maxTicketCount),
         },
         bankInfo: {
-          name: data.bankName,
-          accountNumber: data.accountNumber,
+          name: data.bankName || null,
+          accountNumber: data.accountNumber || null,
         },
       };
 
@@ -54,7 +54,7 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
           ...commonData.eventInfo,
           startDate: data.startDate.split('T')[0],
           startTime: data.startDate.split('T')[1],
-          location: data.location,
+          location: data.location || null,
         },
       };
 
@@ -63,8 +63,8 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
         ...commonData,
         eventInfo: {
           ...commonData.eventInfo,
-          activityArea: data.activityArea,
-          recruitmentTarget: data.recruitmentTarget,
+          activityArea: data.activityArea || null,
+          recruitmentTarget: data.recruitmentTarget || null,
         },
       };
 
@@ -77,7 +77,7 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
           startTime: data.startDate.split('T')[1],
           endDate: data.endDate.split('T')[0],
           endTime: data.endDate.split('T')[1],
-          location: data.location,
+          location: data.location || null,
           dues: parseInt(data.dues),
         },
       };

--- a/src/utils/dataTransform.ts
+++ b/src/utils/dataTransform.ts
@@ -16,7 +16,7 @@ const dataTransform = ({ data, eventType, clubId, eventId }: dataTransform) => {
     ...(eventId ? { eventId } : { clubId }),
     eventInfo: {
       title,
-      content,
+      content: content.trim(),
       capacity: parseInt(capacity),
     },
     formInfo: {

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -6,8 +6,14 @@ import {
 } from '@/constants/club';
 import { ERROR_MESSAGE } from '@/constants/errorMessage';
 
+const { TRIM } = ERROR_MESSAGE.COMMON;
 const { START_TIME } = ERROR_MESSAGE.EVENT;
 const { NAME, NUMBER } = ERROR_MESSAGE.REGISTER;
+
+const validateTrim = (input: string) => {
+  if (!input.trim() && input.length > 0) return TRIM;
+  else return true;
+};
 
 const validateName = (input: string) => {
   const regex = /^[가-힣ㄱ-ㅎㅏ-ㅣ]+$/;
@@ -75,6 +81,7 @@ const validateClubInfo = (clubInfo: string) => {
 };
 
 export {
+  validateTrim,
   validateName,
   validateNumber,
   validateTimeCompare,


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 작업 내용 1: 공연 종류 선택시 선택카드가 커지는 비율을 조정했습니다.
- 작업 내용 2: input에서 마이너스로 값이 바뀌지 않도록 했습니다.
- 작업 내용 3: input type이 number일 경우, 화살표가 보이지 않도록 변경했습니다.
- 작업 내용 4: input type이 number일 경우, 각 input의 단위를 추가했습니다.
- 작업 내용 5: input type이 text일 경우, 공백에 대한 validation을 추가했습니다.
- 작업 내용 6: 포스터 이미지의 속성을 cover로 변경했습니다.
- 작업 내용 7: 공연 내용 제출 시, 앞 뒤에 공백을 제거 후 제출되도록 했습니다.
- 작업 내용 8: 각 정보들이 없을 시, null로 제출되도록 했습니다.

## 구현 스크린샷
- 없습니다.

## ✨pr포인트 & 궁금한 점 
- input type이 datetime-local일 경우, 키보드로 일정이 입력되는 것을 막지 못했는데 방법이 있을까요?
- input type이 datetime-local일 경우, time이 무한 스크롤 되는 것을 막을 방법이 있을까요? 


