### PR TITLE
SKRF-391 fix: 제출된 폼 페이지 QA 반영

### DIFF
--- a/src/apis/interceptor.ts
+++ b/src/apis/interceptor.ts
@@ -19,6 +19,7 @@ const handleTokenError = async (error: AxiosError<HttpException>) => {
   if (error.response?.data.code === EXCEPTION_CODE.INVALID_ACCESS_TOKEN) {
     return axiosClientWithAuth(originalRequest);
   }
+  return Promise.reject(error);
 };
 
 const setToken = (config: InternalAxiosRequestConfig) => {

--- a/src/components/ApplyCancelButton/ApplyCancelButton.style.ts
+++ b/src/components/ApplyCancelButton/ApplyCancelButton.style.ts
@@ -10,6 +10,11 @@ const ButtonStyled = styled.button<{ isCanceled: boolean }>`
   border-radius: ${({ isCanceled }) => (isCanceled ? '0' : '0.3rem')};
   font-size: ${Theme.fontSize.tagText};
   cursor: ${({ isCanceled }) => (isCanceled ? 'default' : 'pointer')};
+
+  :hover {
+    color: white;
+    background-color: ${({ isCanceled }) => (isCanceled ? 'none' : Theme.color.shadow)};
+  }
 `;
 
 const ButtonTextStyled = styled.span`

--- a/src/components/ApplyCancelButton/ApplyCancelButton.tsx
+++ b/src/components/ApplyCancelButton/ApplyCancelButton.tsx
@@ -27,7 +27,7 @@ const ApplyCancelButton = ({ isCanceled, eventId, formUserId }: ApplyCancelButto
         />
       )}
       <ButtonStyled isCanceled={isCanceled} onClick={modalOpen} disabled={isCanceled}>
-        <ButtonTextStyled>{isCanceled ? '취소처리 되었습니다. ' : '취소하기'}</ButtonTextStyled>
+        <ButtonTextStyled>{isCanceled ? '취소완료 ' : '취소하기'}</ButtonTextStyled>
       </ButtonStyled>
     </>
   );

--- a/src/components/ChangeFormStatusButton/ChangeFormStatusButton.style.ts
+++ b/src/components/ChangeFormStatusButton/ChangeFormStatusButton.style.ts
@@ -1,0 +1,25 @@
+import Theme from '@/styles/Theme';
+import { EventStatus } from '@/types/event';
+import styled from '@emotion/styled';
+
+const StatusButtonContainer = styled.button<{ status: EventStatus }>`
+  width: 3rem;
+  height: 1.4rem;
+  border-radius: 0.2rem;
+  outline: none;
+  border: 1px solid;
+  background-color: white;
+  color: ${({ status }) =>
+    status === 'CONFIRMED' ? Theme.color.tSemiActive : Theme.color.textGrey};
+  font-size: ${Theme.fontSize.tagText};
+  cursor: pointer;
+`;
+
+const ButtonValueStyled = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.3rem;
+`;
+
+export { StatusButtonContainer, ButtonValueStyled };

--- a/src/components/ChangeFormStatusButton/ChangeFormStatusButton.tsx
+++ b/src/components/ChangeFormStatusButton/ChangeFormStatusButton.tsx
@@ -1,0 +1,47 @@
+import useSubmittedFormStatusMutation from '@/hooks/query/form/useSubmittedFormStatusMutation';
+import { EventStatus } from '@/types/event';
+
+import { FaCheckCircle } from 'react-icons/fa';
+import { FaRegCheckCircle } from 'react-icons/fa';
+
+import { ButtonValueStyled, StatusButtonContainer } from './ChangeFormStatusButton.style';
+
+interface ChangeFormStatusButtonProps {
+  eventId: string;
+  formId: string;
+  status: EventStatus;
+}
+
+const ChangeFormStatusButton = ({ eventId, formId, status }: ChangeFormStatusButtonProps) => {
+  const { changeSubmittedFormStatus } = useSubmittedFormStatusMutation();
+
+  return (
+    <StatusButtonContainer
+      status={status}
+      onClick={() =>
+        changeSubmittedFormStatus({
+          eventId,
+          formUserId: formId,
+          participationStatus: status === 'CONFIRMED' ? 'PENDING' : 'CONFIRMED',
+        })
+      }
+      disabled={status === 'CANCELED'}
+    >
+      <ButtonValueStyled>
+        {status === 'CONFIRMED' ? (
+          <>
+            <FaCheckCircle size={12} />
+            <span>확인</span>
+          </>
+        ) : (
+          <>
+            <FaRegCheckCircle size={12} />
+            <span>대기</span>
+          </>
+        )}
+      </ButtonValueStyled>
+    </StatusButtonContainer>
+  );
+};
+
+export default ChangeFormStatusButton;

--- a/src/components/ChangeFormStatusButton/ChangeFormStatusButton.tsx
+++ b/src/components/ChangeFormStatusButton/ChangeFormStatusButton.tsx
@@ -1,9 +1,11 @@
 import useSubmittedFormStatusMutation from '@/hooks/query/form/useSubmittedFormStatusMutation';
+import useModal from '@/hooks/useModal';
 import { EventStatus } from '@/types/event';
 
 import { FaCheckCircle } from 'react-icons/fa';
 import { FaRegCheckCircle } from 'react-icons/fa';
 
+import ConfirmModal from '../Modals/ConfirmModal';
 import { ButtonValueStyled, StatusButtonContainer } from './ChangeFormStatusButton.style';
 
 interface ChangeFormStatusButtonProps {
@@ -14,33 +16,43 @@ interface ChangeFormStatusButtonProps {
 
 const ChangeFormStatusButton = ({ eventId, formId, status }: ChangeFormStatusButtonProps) => {
   const { changeSubmittedFormStatus } = useSubmittedFormStatusMutation();
+  const { showModal, modalOpen, modalClose } = useModal();
 
   return (
-    <StatusButtonContainer
-      status={status}
-      onClick={() =>
-        changeSubmittedFormStatus({
-          eventId,
-          formUserId: formId,
-          participationStatus: status === 'CONFIRMED' ? 'PENDING' : 'CONFIRMED',
-        })
-      }
-      disabled={status === 'CANCELED'}
-    >
-      <ButtonValueStyled>
-        {status === 'CONFIRMED' ? (
-          <>
-            <FaCheckCircle size={12} />
-            <span>확인</span>
-          </>
-        ) : (
-          <>
-            <FaRegCheckCircle size={12} />
-            <span>대기</span>
-          </>
-        )}
-      </ButtonValueStyled>
-    </StatusButtonContainer>
+    <>
+      {showModal && (
+        <ConfirmModal
+          message={`상태를 ${status === 'CONFIRMED' ? '"대기"로' : '"확인"으로'} 변경하시겠습니까?`}
+          onConfirm={() =>
+            changeSubmittedFormStatus({
+              eventId,
+              formUserId: formId,
+              participationStatus: status === 'CONFIRMED' ? 'PENDING' : 'CONFIRMED',
+            })
+          }
+          onClose={modalClose}
+        />
+      )}
+      <StatusButtonContainer
+        status={status}
+        onClick={() => modalOpen()}
+        disabled={status === 'CANCELED'}
+      >
+        <ButtonValueStyled>
+          {status === 'CONFIRMED' ? (
+            <>
+              <FaCheckCircle size={12} />
+              <span>확인</span>
+            </>
+          ) : (
+            <>
+              <FaRegCheckCircle size={12} />
+              <span>대기</span>
+            </>
+          )}
+        </ButtonValueStyled>
+      </StatusButtonContainer>
+    </>
   );
 };
 

--- a/src/components/Modals/FormDetailModal/FormDetailModal.style.ts
+++ b/src/components/Modals/FormDetailModal/FormDetailModal.style.ts
@@ -2,6 +2,11 @@ import Theme from '@/styles/Theme';
 import { memberManagerScrollAreaStyled } from '@/styles/common';
 import styled from '@emotion/styled';
 
+const SubmittedFormDetailTitleStyled = styled.h1`
+  color: black;
+  font-size: ${Theme.fontSize.smallTitle};
+`;
+
 const FormDetailModalContainer = styled(memberManagerScrollAreaStyled)`
   display: flex;
   flex-direction: column;
@@ -21,4 +26,4 @@ const FormDetailModalContainer = styled(memberManagerScrollAreaStyled)`
   overflow: auto;
 `;
 
-export { FormDetailModalContainer };
+export { SubmittedFormDetailTitleStyled, FormDetailModalContainer };

--- a/src/components/Modals/FormDetailModal/FormDetailModal.tsx
+++ b/src/components/Modals/FormDetailModal/FormDetailModal.tsx
@@ -15,7 +15,7 @@ const FormDetailModal = ({ onClose, options, dateTime }: FormDetailModalProps) =
     <Portal>
       <BackgroundOverlay onClick={onClose}>
         <FormDetailModalContainer>
-          <SubmittedFormDetailTitleStyled>{dateTime}</SubmittedFormDetailTitleStyled>
+          <SubmittedFormDetailTitleStyled>{`제출시간: ${dateTime}`}</SubmittedFormDetailTitleStyled>
           {options.map((option, index) => {
             return (
               <FormItemContainer key={index}>

--- a/src/components/Modals/FormDetailModal/FormDetailModal.tsx
+++ b/src/components/Modals/FormDetailModal/FormDetailModal.tsx
@@ -2,19 +2,20 @@ import { FormItemContainer, QuestionStyled } from '@/components/FormItem/FormIte
 
 import { BackgroundOverlay } from '../Modal.style';
 import Portal from '../Portal';
-import { FormDetailModalContainer } from './FormDetailModal.style';
+import { FormDetailModalContainer, SubmittedFormDetailTitleStyled } from './FormDetailModal.style';
 
 interface FormDetailModalProps {
   onClose: () => void;
   options: { title: string; content: string }[];
+  dateTime: string;
 }
 
-const FormDetailModal = ({ onClose, options }: FormDetailModalProps) => {
-  //#TODO: api response로 제출된 시각 추가해주면 상단에 넣기
+const FormDetailModal = ({ onClose, options, dateTime }: FormDetailModalProps) => {
   return (
     <Portal>
       <BackgroundOverlay onClick={onClose}>
         <FormDetailModalContainer>
+          <SubmittedFormDetailTitleStyled>{dateTime}</SubmittedFormDetailTitleStyled>
           {options.map((option, index) => {
             return (
               <FormItemContainer key={index}>

--- a/src/components/Modals/FormDetailModal/FormDetailModal.tsx
+++ b/src/components/Modals/FormDetailModal/FormDetailModal.tsx
@@ -7,15 +7,15 @@ import { FormDetailModalContainer, SubmittedFormDetailTitleStyled } from './Form
 interface FormDetailModalProps {
   onClose: () => void;
   options: { title: string; content: string }[];
-  dateTime: string;
+  nthForm: number;
 }
 
-const FormDetailModal = ({ onClose, options, dateTime }: FormDetailModalProps) => {
+const FormDetailModal = ({ onClose, options, nthForm }: FormDetailModalProps) => {
   return (
     <Portal>
       <BackgroundOverlay onClick={onClose}>
         <FormDetailModalContainer>
-          <SubmittedFormDetailTitleStyled>{`제출시간: ${dateTime}`}</SubmittedFormDetailTitleStyled>
+          <SubmittedFormDetailTitleStyled>{`${nthForm}번째 폼`}</SubmittedFormDetailTitleStyled>
           {options.map((option, index) => {
             return (
               <FormItemContainer key={index}>

--- a/src/components/SubmittedForms/Category/Category.style.ts
+++ b/src/components/SubmittedForms/Category/Category.style.ts
@@ -11,7 +11,7 @@ const CategoryStyled = styled.div`
 `;
 
 const CategoryRowStyled = styled.div`
-  width: 4rem;
+  min-width: 10rem;
 `;
 
 const CategoryItemStyled = styled.div`

--- a/src/components/SubmittedForms/Category/Category.style.ts
+++ b/src/components/SubmittedForms/Category/Category.style.ts
@@ -25,7 +25,7 @@ const ManageTitleStyled = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 6rem;
+  min-width: 6rem;
 `;
 
 export { CategoryStyled, CategoryRowStyled, CategoryItemStyled, ManageTitleStyled };

--- a/src/components/SubmittedForms/Category/Category.style.ts
+++ b/src/components/SubmittedForms/Category/Category.style.ts
@@ -10,6 +10,10 @@ const CategoryStyled = styled.div`
   font-size: ${Theme.fontSize.largeContent};
 `;
 
+const CategoryNthStyled = styled.div`
+  min-width: 4rem;
+`;
+
 const CategoryRowStyled = styled.div`
   min-width: 10rem;
 `;
@@ -28,4 +32,10 @@ const ManageTitleStyled = styled.div`
   min-width: 6rem;
 `;
 
-export { CategoryStyled, CategoryRowStyled, CategoryItemStyled, ManageTitleStyled };
+export {
+  CategoryStyled,
+  CategoryNthStyled,
+  CategoryRowStyled,
+  CategoryItemStyled,
+  ManageTitleStyled,
+};

--- a/src/components/SubmittedForms/Category/Category.tsx
+++ b/src/components/SubmittedForms/Category/Category.tsx
@@ -1,5 +1,6 @@
 import {
   CategoryItemStyled,
+  CategoryNthStyled,
   CategoryRowStyled,
   CategoryStyled,
   ManageTitleStyled,
@@ -15,7 +16,7 @@ const Category = ({ optionTitles, managed }: CategoryProps) => {
 
   return (
     <CategoryStyled>
-      <CategoryItemStyled>순서</CategoryItemStyled>
+      <CategoryNthStyled>순서</CategoryNthStyled>
       <CategoryRowStyled>제출시간</CategoryRowStyled>
       {optionTitles.map((title, index) => {
         return <CategoryItemStyled key={index}>{title}</CategoryItemStyled>;

--- a/src/components/SubmittedForms/Category/Category.tsx
+++ b/src/components/SubmittedForms/Category/Category.tsx
@@ -15,6 +15,7 @@ const Category = ({ optionTitles, managed }: CategoryProps) => {
 
   return (
     <CategoryStyled>
+      <CategoryItemStyled>순서</CategoryItemStyled>
       <CategoryRowStyled>제출시간</CategoryRowStyled>
       {optionTitles.map((title, index) => {
         return <CategoryItemStyled key={index}>{title}</CategoryItemStyled>;

--- a/src/components/SubmittedForms/Category/Category.tsx
+++ b/src/components/SubmittedForms/Category/Category.tsx
@@ -15,7 +15,7 @@ const Category = ({ optionTitles, managed }: CategoryProps) => {
 
   return (
     <CategoryStyled>
-      <CategoryRowStyled>순서</CategoryRowStyled>
+      <CategoryRowStyled>제출시간</CategoryRowStyled>
       {optionTitles.map((title, index) => {
         return <CategoryItemStyled key={index}>{title}</CategoryItemStyled>;
       })}

--- a/src/components/SubmittedForms/FormStatus/FormStatus.style.ts
+++ b/src/components/SubmittedForms/FormStatus/FormStatus.style.ts
@@ -1,10 +1,7 @@
 import styled from '@emotion/styled';
 
-const FormStatusItemStyled = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 6rem;
-`;
+import { ManageTitleStyled } from '../Category/Category.style';
+
+const FormStatusItemStyled = styled(ManageTitleStyled)``;
 
 export { FormStatusItemStyled };

--- a/src/components/SubmittedForms/FormStatus/FormStatus.tsx
+++ b/src/components/SubmittedForms/FormStatus/FormStatus.tsx
@@ -1,12 +1,10 @@
-import { FORM_STATUS_DROPDOWN_OPTIONS } from '@/constants/form';
-import useSubmittedFormStatusMutation from '@/hooks/query/form/useSubmittedFormStatusMutation';
+import ChangeFormStatusButton from '@/components/ChangeFormStatusButton/ChangeFormStatusButton';
 import { EventStatus } from '@/types/event';
 import { getEventStatusTag } from '@/utils/getEventStatusTag';
 
 import { useParams } from 'react-router-dom';
 
 import ApplyCancelButton from '../../ApplyCancelButton/ApplyCancelButton';
-import DropDown from '../../common/DropDown/DropDown';
 import { FormStatusItemStyled } from './FormStatus.style';
 
 interface FormStatus {
@@ -16,7 +14,6 @@ interface FormStatus {
 
 const FormStatus = ({ id, participationStatus }: FormStatus) => {
   const { eventId } = useParams();
-  const { changeSubmittedFormStatus } = useSubmittedFormStatusMutation();
   if (!eventId) {
     return null;
   }
@@ -25,18 +22,7 @@ const FormStatus = ({ id, participationStatus }: FormStatus) => {
     <>
       <FormStatusItemStyled>{getEventStatusTag(participationStatus)}</FormStatusItemStyled>
       <FormStatusItemStyled>
-        <DropDown
-          options={FORM_STATUS_DROPDOWN_OPTIONS}
-          selectedValue={participationStatus === 'CONFIRMED' ? 'CONFIRMED' : 'PENDING'}
-          onChange={(event) => {
-            changeSubmittedFormStatus({
-              eventId,
-              formUserId: id,
-              participationStatus: event.target.value as EventStatus,
-            });
-          }}
-          disabled={participationStatus === 'CANCELED'}
-        />
+        <ChangeFormStatusButton status={participationStatus} eventId={eventId} formId={id} />
       </FormStatusItemStyled>
       <FormStatusItemStyled>
         <ApplyCancelButton

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
@@ -1,7 +1,11 @@
 import Theme from '@/styles/Theme';
 import styled from '@emotion/styled';
 
-import { CategoryItemStyled, CategoryRowStyled } from '../Category/Category.style';
+import {
+  CategoryItemStyled,
+  CategoryNthStyled,
+  CategoryRowStyled,
+} from '../Category/Category.style';
 
 const FormStyled = styled.div`
   display: flex;
@@ -15,10 +19,12 @@ const FormStyled = styled.div`
   }
 `;
 
+const FormNthStyled = styled(CategoryNthStyled)``;
+
 const FormRowStyled = styled(CategoryRowStyled)``;
 
 const FormItemStyled = styled(CategoryItemStyled)`
   cursor: pointer;
 `;
 
-export { FormStyled, FormRowStyled, FormItemStyled };
+export { FormStyled, FormNthStyled, FormRowStyled, FormItemStyled };

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
@@ -17,6 +17,8 @@ const FormStyled = styled.div`
 
 const FormRowStyled = styled(CategoryRowStyled)``;
 
-const FormItemStyled = styled(CategoryItemStyled)``;
+const FormItemStyled = styled(CategoryItemStyled)`
+  cursor: pointer;
+`;
 
 export { FormStyled, FormRowStyled, FormItemStyled };

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.style.ts
@@ -6,7 +6,7 @@ import { CategoryItemStyled, CategoryRowStyled } from '../Category/Category.styl
 const FormStyled = styled.div`
   display: flex;
   align-items: center;
-  height: 2rem;
+  height: 3rem;
   border-bottom: 1px solid ${Theme.color.tSeparator};
   font-size: ${Theme.fontSize.smallContent};
 

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
@@ -36,6 +36,7 @@ const SubmittedForm = ({
     <>
       {showModal && <FormDetailModal onClose={modalClose} options={options} nthForm={nthForm} />}
       <FormStyled key={index}>
+        <FormItemStyled>{nthForm}</FormItemStyled>
         <FormRowStyled>{dateTime}</FormRowStyled>
         {options.map((option, index) => (
           <FormItemStyled onClick={modalOpen} key={index}>

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
@@ -3,7 +3,7 @@ import useModal from '@/hooks/useModal';
 import { EventStatus } from '@/types/event';
 
 import FormStatus from '../FormStatus/FormStatus';
-import { FormItemStyled, FormRowStyled, FormStyled } from './SubmittedForm.style';
+import { FormItemStyled, FormNthStyled, FormRowStyled, FormStyled } from './SubmittedForm.style';
 
 interface SubmittedFormProps {
   index: number;
@@ -36,7 +36,7 @@ const SubmittedForm = ({
     <>
       {showModal && <FormDetailModal onClose={modalClose} options={options} nthForm={nthForm} />}
       <FormStyled key={index}>
-        <FormItemStyled>{nthForm}</FormItemStyled>
+        <FormNthStyled>{nthForm}</FormNthStyled>
         <FormRowStyled>{dateTime}</FormRowStyled>
         {options.map((option, index) => (
           <FormItemStyled onClick={modalOpen} key={index}>

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
@@ -8,37 +8,32 @@ import { FormItemStyled, FormRowStyled, FormStyled } from './SubmittedForm.style
 interface SubmittedFormProps {
   index: number;
   userId: string;
-  formLength: number;
   options: {
     title: string;
     content: string;
   }[];
-  participationStatus: EventStatus;
+  participation: {
+    status: EventStatus;
+    dateTime: string;
+  };
   managed: boolean;
 }
 
-const SubmittedForm = ({
-  index,
-  userId,
-  formLength,
-  options,
-  participationStatus,
-  managed,
-}: SubmittedFormProps) => {
+const SubmittedForm = ({ index, userId, options, participation, managed }: SubmittedFormProps) => {
   const { showModal, modalOpen, modalClose } = useModal();
-  //#TODO: 제출된 시각 추가되면 넣기=>순서 대신 제출된 시간을 보여주는 게 어떨까?
+  const { status, dateTime } = participation;
 
   return (
     <>
-      {showModal && <FormDetailModal onClose={modalClose} options={options} />}
+      {showModal && <FormDetailModal onClose={modalClose} options={options} dateTime={dateTime} />}
       <FormStyled key={index}>
-        <FormRowStyled>{formLength - index}</FormRowStyled>
+        <FormRowStyled>{participation.dateTime}</FormRowStyled>
         {options.map((option, index) => (
           <FormItemStyled onClick={modalOpen} key={index}>
             {option.content}
           </FormItemStyled>
         ))}
-        {managed && <FormStatus id={userId} participationStatus={participationStatus} />}
+        {managed && <FormStatus id={userId} participationStatus={status} />}
       </FormStyled>
     </>
   );

--- a/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
+++ b/src/components/SubmittedForms/SubmittedForm/SubmittedForm.tsx
@@ -7,6 +7,7 @@ import { FormItemStyled, FormRowStyled, FormStyled } from './SubmittedForm.style
 
 interface SubmittedFormProps {
   index: number;
+  formLength: number;
   userId: string;
   options: {
     title: string;
@@ -19,15 +20,23 @@ interface SubmittedFormProps {
   managed: boolean;
 }
 
-const SubmittedForm = ({ index, userId, options, participation, managed }: SubmittedFormProps) => {
+const SubmittedForm = ({
+  index,
+  formLength,
+  userId,
+  options,
+  participation,
+  managed,
+}: SubmittedFormProps) => {
   const { showModal, modalOpen, modalClose } = useModal();
   const { status, dateTime } = participation;
+  const nthForm = formLength - index;
 
   return (
     <>
-      {showModal && <FormDetailModal onClose={modalClose} options={options} dateTime={dateTime} />}
+      {showModal && <FormDetailModal onClose={modalClose} options={options} nthForm={nthForm} />}
       <FormStyled key={index}>
-        <FormRowStyled>{participation.dateTime}</FormRowStyled>
+        <FormRowStyled>{dateTime}</FormRowStyled>
         {options.map((option, index) => (
           <FormItemStyled onClick={modalOpen} key={index}>
             {option.content}

--- a/src/components/SubmittedForms/SubmittedForms.style.ts
+++ b/src/components/SubmittedForms/SubmittedForms.style.ts
@@ -11,7 +11,7 @@ const SubmittedFormsWrapper = styled.div`
   justify-content: center;
   overflow-x: auto;
   width: 100%;
-  min-width: 40rem;
+  min-width: 30rem;
 `;
 
 const FormLengthStyled = styled.div`

--- a/src/components/SubmittedForms/SubmittedForms.tsx
+++ b/src/components/SubmittedForms/SubmittedForms.tsx
@@ -20,6 +20,7 @@ const SubmittedForms = ({ formInfo, userForms }: { formInfo: FormInfo; userForms
             return (
               <SubmittedForm
                 key={form.userId}
+                formLength={formInfo.count}
                 index={index}
                 userId={form.userId}
                 options={form.options}

--- a/src/components/SubmittedForms/SubmittedForms.tsx
+++ b/src/components/SubmittedForms/SubmittedForms.tsx
@@ -21,10 +21,9 @@ const SubmittedForms = ({ formInfo, userForms }: { formInfo: FormInfo; userForms
               <SubmittedForm
                 key={form.userId}
                 index={index}
-                formLength={formInfo.count}
                 userId={form.userId}
                 options={form.options}
-                participationStatus={form.participationStatus}
+                participation={form.participation}
                 managed={formInfo.managed}
               />
             );

--- a/src/hooks/query/form/useSubmittedFormStatusMutation.ts
+++ b/src/hooks/query/form/useSubmittedFormStatusMutation.ts
@@ -1,4 +1,5 @@
 import patchSubmittedFormStatus from '@/apis/form/patchSubmittedFormStatus';
+import useToast from '@/hooks/useToast';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -6,13 +7,16 @@ import { QUERY_KEY } from '../event/useGetSubmittedFormsQuery';
 
 const useSubmittedFormStatusMutation = () => {
   const queryClient = useQueryClient();
+  const { createToast } = useToast();
 
   const { mutate: changeSubmittedFormStatus } = useMutation({
     mutationFn: patchSubmittedFormStatus,
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.SUBMITTED_FORMS]);
     },
-    onError: () => {}, //실패 토스트 메시지
+    onError: () => {
+      createToast({ message: '폼 상태 변경에 실패했습니다.', toastType: 'error' });
+    },
   });
 
   return { changeSubmittedFormStatus };

--- a/src/pages/event/SubmittedFormsPage/SubmittedFormsPage.style.ts
+++ b/src/pages/event/SubmittedFormsPage/SubmittedFormsPage.style.ts
@@ -4,6 +4,7 @@ const SubmittedFormsWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 70vh;
 `;
 
 export { SubmittedFormsWrapper };

--- a/src/types/forms.ts
+++ b/src/types/forms.ts
@@ -1,3 +1,5 @@
+import { EventStatus } from './event';
+
 interface Form {
   title: string;
   content: string; //#TODO: boolean일 수도 있음 (체크박스?)
@@ -6,7 +8,10 @@ interface Form {
 interface UserForm {
   userId: string;
   options: Form[];
-  participationStatus: 'PENDING' | 'CONFIRMED' | 'CANCELED' | 'CANCEL_REQUESTED';
+  participation: {
+    status: EventStatus;
+    dateTime: string;
+  };
 }
 
 interface FormInfo {


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 제출된 폼 상세보기 커서포인터로 바꾸기
- 상태 선택 시 버튼이나 원클릭 요소(체크박스)로 바꾸기
- 페이지네이션 하에 두기
- 취소처리 되었으면 ‘취소완료’로 바꾸기
- 제출된 폼 상세보기에 타이틀 달아주기: 제출된 시각으로
- 제출된 폼에 제출시간 넣어주기

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/98521882/2f8ed264-d2f4-4435-b2a2-3b8494419d46)
![image](https://github.com/Space-Club/Frontend/assets/98521882/b42f984a-dc66-45fd-a010-ddda1f073267)
![image](https://github.com/Space-Club/Frontend/assets/98521882/49a03cb3-229c-4c61-b35a-63323f3da140)

리뷰 반영 후
![image](https://github.com/Space-Club/Frontend/assets/98521882/a44c9d5f-2720-465d-b654-1a28411c70b3)


## ✨pr포인트 & 궁금한 점 



