### PR TITLE
SKRF-330 feat: 신청 막는 기능 구현

### DIFF
--- a/src/components/UserApplyButton/UserApplyButton.tsx
+++ b/src/components/UserApplyButton/UserApplyButton.tsx
@@ -20,14 +20,14 @@ interface UserApplyButton {
 const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButton) => {
   const bookmarkRef = useRef<HTMLDivElement>(null);
   const { isBookmarked } = useIsBookmarkedQuery({ eventId });
-  const { hasAlreadyApplied, eventInfo, formInfo } = eventDetail ?? {};
+  const { category, hasAlreadyApplied, eventInfo, formInfo } = eventDetail ?? {};
   const { capacity, applicants, isEnded } = eventInfo ?? {};
   const { isAbleToApply } = formInfo ?? {};
 
   const checkApplyButtonText = () => {
     if (hasAlreadyApplied) {
       return EVENT_DETAIL_BUTTON.apply.completed;
-    } else if (applicants >= capacity) {
+    } else if (category !== 'RECRUITMENT' && applicants >= capacity) {
       return EVENT_DETAIL_BUTTON.apply.soldOut;
     } else if (isEnded || isAbleToApply) {
       return EVENT_DETAIL_BUTTON.apply.deadLine;
@@ -42,7 +42,7 @@ const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButt
         <ApplicantButton
           reverse
           capacity={!!capacity}
-          isDisabled={hasAlreadyApplied || isEnded || isAbleToApply || applicants >= capacity}
+          isDisabled={checkApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
           disabled
         >
           {applicants}/{capacity}
@@ -50,7 +50,7 @@ const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButt
       )}
       <ApplyButton
         capacity={Boolean(capacity)}
-        disabled={hasAlreadyApplied || isEnded || isAbleToApply || applicants >= capacity}
+        disabled={checkApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
         onClick={() => applyModalOpen()}
       >
         {checkApplyButtonText()}

--- a/src/components/UserApplyButton/UserApplyButton.tsx
+++ b/src/components/UserApplyButton/UserApplyButton.tsx
@@ -1,6 +1,6 @@
 import BookMark from '@/components/common/BookMark/BookMark';
 import { EVENT_DETAIL_BUTTON } from '@/constants/event';
-import useIsBookmarkQuery from '@/hooks/query/event/useIsBookmarkedQuery';
+import useIsBookmarkedQuery from '@/hooks/query/event/useIsBookmarkedQuery';
 import {
   ApplicantButton,
   ApplyButton,
@@ -19,24 +19,41 @@ interface UserApplyButton {
 
 const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButton) => {
   const bookmarkRef = useRef<HTMLDivElement>(null);
-  const { isBookmarked } = useIsBookmarkQuery({ eventId });
-  const { eventInfo, formInfo } = eventDetail ?? {};
+  const { isBookmarked } = useIsBookmarkedQuery({ eventId });
+  const { hasAlreadyApplied, eventInfo, formInfo } = eventDetail ?? {};
   const { capacity, applicants, isEnded } = eventInfo ?? {};
   const { isAbleToApply } = formInfo ?? {};
+
+  const checkApplyButtonText = () => {
+    if (hasAlreadyApplied) {
+      return EVENT_DETAIL_BUTTON.apply.completed;
+    } else if (applicants >= capacity) {
+      return EVENT_DETAIL_BUTTON.apply.soldOut;
+    } else if (isEnded || isAbleToApply) {
+      return EVENT_DETAIL_BUTTON.apply.deadLine;
+    } else {
+      return EVENT_DETAIL_BUTTON.apply.possible;
+    }
+  };
 
   return (
     <ButtonWrapper>
       {capacity && (
-        <ApplicantButton reverse capacity={!!capacity} disabled>
+        <ApplicantButton
+          reverse
+          capacity={!!capacity}
+          isDisabled={hasAlreadyApplied || isEnded || isAbleToApply || applicants >= capacity}
+          disabled
+        >
           {applicants}/{capacity}
         </ApplicantButton>
       )}
       <ApplyButton
         capacity={Boolean(capacity)}
-        disabled={isEnded || isAbleToApply}
+        disabled={hasAlreadyApplied || isEnded || isAbleToApply || applicants >= capacity}
         onClick={() => applyModalOpen()}
       >
-        {EVENT_DETAIL_BUTTON.apply}
+        {checkApplyButtonText()}
       </ApplyButton>
       <BookmarkButton reverse bold onClick={() => bookmarkRef.current?.click()}>
         <BookMark bookmarked={isBookmarked!} eventId={eventId} ref={bookmarkRef} />

--- a/src/components/UserApplyButton/UserApplyButton.tsx
+++ b/src/components/UserApplyButton/UserApplyButton.tsx
@@ -24,7 +24,7 @@ const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButt
   const { capacity, applicants, isEnded } = eventInfo ?? {};
   const { isAbleToApply } = formInfo ?? {};
 
-  const checkApplyButtonText = () => {
+  const getApplyButtonText = () => {
     if (hasAlreadyApplied) {
       return EVENT_DETAIL_BUTTON.apply.completed;
     } else if (category !== 'RECRUITMENT' && applicants >= capacity) {
@@ -42,7 +42,7 @@ const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButt
         <ApplicantButton
           reverse
           capacity={!!capacity}
-          isDisabled={checkApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
+          isDisabled={getApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
           disabled
         >
           {applicants}/{capacity}
@@ -50,10 +50,10 @@ const UserApplyButton = ({ eventId, eventDetail, applyModalOpen }: UserApplyButt
       )}
       <ApplyButton
         capacity={Boolean(capacity)}
-        disabled={checkApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
+        disabled={getApplyButtonText() !== EVENT_DETAIL_BUTTON.apply.possible}
         onClick={() => applyModalOpen()}
       >
-        {checkApplyButtonText()}
+        {getApplyButtonText()}
       </ApplyButton>
       <BookmarkButton reverse bold onClick={() => bookmarkRef.current?.click()}>
         <BookMark bookmarked={isBookmarked!} eventId={eventId} ref={bookmarkRef} />

--- a/src/constants/event.ts
+++ b/src/constants/event.ts
@@ -56,7 +56,12 @@ const EVENT_DETAIL_BUTTON = {
   showSubmitForm: '제출된 폼 보기',
   edit: '수정하기',
   delete: '삭제하기',
-  apply: '참여 신청하기',
+  apply: {
+    completed: '신청 완료',
+    soldOut: 'SOLD OUT',
+    deadLine: '신청 마감',
+    possible: '참여 신청하기',
+  },
 };
 
 const SUBMIT_FORM_OPTIONS = {

--- a/src/pages/event/EventDetailPage/EventDetailPage.style.ts
+++ b/src/pages/event/EventDetailPage/EventDetailPage.style.ts
@@ -62,15 +62,15 @@ const ButtonWrapper = styled.div`
   height: 4rem;
 `;
 
-const ApplicantButton = styled(SemiPurpleButton)<{ capacity: boolean }>`
+const ApplicantButton = styled(SemiPurpleButton)<{ capacity: boolean; isDisabled: boolean }>`
   display: ${({ capacity }) => (capacity ? 'block' : 'none')};
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   padding: 0 1rem;
+  cursor: revert;
 
-  &:hover {
-    cursor: revert;
-  }
+  color: ${({ isDisabled }) => isDisabled && Theme.color.idkGrey};
+  border-color: ${({ isDisabled }) => isDisabled && Theme.color.idkGrey};
 `;
 const ApplyButton = styled(SemiPurpleButton)<{ capacity: boolean }>`
   width: 30%;
@@ -79,7 +79,9 @@ const ApplyButton = styled(SemiPurpleButton)<{ capacity: boolean }>`
   font-size: ${Theme.fontSize.mediumContent};
 
   &:disabled {
-    cursor: revert;
+    background-color: ${Theme.color.idkGrey};
+    border-color: transparent;
+    cursor: not-allowed;
   }
 `;
 const BookmarkButton = styled(SemiPurpleButton)`

--- a/src/types/api/getEventDetail.ts
+++ b/src/types/api/getEventDetail.ts
@@ -11,6 +11,7 @@ type getEventDetailResponse =
 interface CommonDetailResponse {
   id: number;
   hasForm: boolean;
+  hasAlreadyApplied: boolean;
   clubInfo: {
     clubId: string;
     clubName: string;


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 작업 내용 1: 아래의 4가지 경우에 대해 신청을 막는 기능을 구현했습니다.
  1. 모집인원이 다 찼을 경우
  2. 폼 신청 기간이 지났을 경우
  3. 공연 기간이 지난 경우
  4. 이미 공연을 신청한 경우

## 구현 스크린샷
<img width="1440" alt="스크린샷 2023-11-29 오후 3 34 09" src="https://github.com/Space-Club/Frontend/assets/44944877/fc2f05a0-eabb-4b08-9b90-8a66bcbd17d8">
<img width="1440" alt="스크린샷 2023-11-29 오후 3 34 23" src="https://github.com/Space-Club/Frontend/assets/44944877/b252d13d-6436-4b38-84c3-6f18b4d8279d">
<img width="1440" alt="스크린샷 2023-11-29 오후 3 35 25" src="https://github.com/Space-Club/Frontend/assets/44944877/6d6c4d01-e4e6-4a21-88b7-bfad609c36b0">


## ✨pr포인트 & 궁금한 점 
- 상세페이지에 들어갔을 때의 지원자 수 기준으로 인원이 다 찼는지 여부를 검사하고 있는데,
신청이 되는 순간은 폼 작성을 끝마치고 버튼을 누른 순간이므로 그 사이에 여러 명이 신청할 경우가 있습니다.
이 경우에는 백엔드의 에러메시지를 보고 그에 따라서, 신청이 마감되었다고 보여주는 기능의 추가 구현이 필요할 것 같습니다.
- 모집공고의 경우에는 뽑는 인원과 신청은 계속 받을 수 있다고 생각하는데, 이에 대해 어떻게 생각하시나요?


