### PR TITLE
SKRF-423 fix : 캐러샐 currentIndex항상 범위 내에 존재하게 수정

### DIFF
--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -41,6 +41,8 @@ const useCarousel = ({ totalItem }: UseCarouselProps) => {
   useEffect(() => {
     if (currentIndex > totalItem - 1) {
       setCurrentIndex(totalItem - 1);
+    } else if (currentIndex < 0) {
+      setCurrentIndex(0);
     }
   }, [totalItem, currentIndex]);
 


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 첫 공지사항을 작성할 때 캐러샐이 0/1로 표기되는 오류를 수정했습니다

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/42764685/ad9aeddc-0991-4ffc-a7af-325875e6d0fc)

## ✨pr포인트 & 궁금한 점 



