### PR TITLE
SKRF-379 fix: 서스펜스 오류 해결

### DIFF
--- a/src/components/ClubEvents/ClubEvent.style.ts
+++ b/src/components/ClubEvents/ClubEvent.style.ts
@@ -1,0 +1,13 @@
+import Theme from '@/styles/Theme';
+import styled from '@emotion/styled';
+
+const EmptyClubEvent = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 60vh;
+  font-size: ${Theme.fontSize.mediumContent};
+`;
+
+export { EmptyClubEvent };

--- a/src/components/ClubEvents/ClubEvents.tsx
+++ b/src/components/ClubEvents/ClubEvents.tsx
@@ -1,0 +1,60 @@
+import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
+import { CommonEmptyEventsWrapper, EventsWrapper } from '@/styles/common';
+
+import { useState } from 'react';
+
+import EventCard from '../common/EventCard/EventCard';
+import Pagination from '../common/Pagination/Pagination';
+import { EmptyClubEvent } from './ClubEvent.style';
+
+interface ClubEventsProps {
+  clubId: string;
+}
+
+const ClubEvents = ({ clubId }: ClubEventsProps) => {
+  const [currentPage, setCurrentPage] = useState(0);
+  const { clubEvents, pageData } = useClubEventsQuery({ clubId, pageNumber: currentPage });
+  if (!pageData) {
+    return null;
+  }
+  const { totalPages, size } = pageData;
+
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <>
+      <EventsWrapper>
+        {clubEvents?.map(({ id, eventInfo, clubInfo }) => (
+          <EventCard
+            key={id}
+            eventId={id}
+            posterSrc={eventInfo.posterImageUrl}
+            eventTitle={eventInfo.title}
+            startDate={eventInfo.startDate}
+            endDate={eventInfo.endDate}
+            location={eventInfo.location}
+            clubLogoImageUrl={clubInfo.logoImageUrl}
+            clubName={clubInfo.name}
+            openStatus={eventInfo.openStatus}
+            isEnded={eventInfo.isEnded}
+          />
+        ))}
+      </EventsWrapper>
+      {clubEvents?.length === 0 && (
+        <CommonEmptyEventsWrapper>
+          <EmptyClubEvent>클럽에서 생성한 행사가 없습니다!</EmptyClubEvent>
+        </CommonEmptyEventsWrapper>
+      )}
+      <Pagination
+        totalPages={totalPages}
+        size={size}
+        onChangePage={handleChangePage}
+        currentPage={currentPage}
+      />
+    </>
+  );
+};
+
+export default ClubEvents;

--- a/src/components/MainEvents.tsx
+++ b/src/components/MainEvents.tsx
@@ -3,8 +3,8 @@ import { EventsWrapper } from '@/styles/common';
 
 import { useEffect, useState } from 'react';
 
-import EventCard from '../common/EventCard/EventCard';
-import Pagination from '../common/Pagination/Pagination';
+import EventCard from './common/EventCard/EventCard';
+import Pagination from './common/Pagination/Pagination';
 
 interface MainEventsProps {
   pathname: string;

--- a/src/components/MainEvents/MainEvents.tsx
+++ b/src/components/MainEvents/MainEvents.tsx
@@ -1,0 +1,68 @@
+import useAllEventsQuery from '@/hooks/query/event/useAllEventsQuery';
+import { EventsWrapper } from '@/styles/common';
+
+import { useEffect, useState } from 'react';
+
+import EventCard from '../common/EventCard/EventCard';
+import Pagination from '../common/Pagination/Pagination';
+
+interface MainEventsProps {
+  pathname: string;
+}
+
+const MainEvents = ({ pathname }: MainEventsProps) => {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [pathname]);
+
+  const { events, pageData } = useAllEventsQuery(
+    {
+      pageNumber: currentPage,
+      category: pathname === '/' ? 'SHOW' : pathname === '/events' ? 'PROMOTION' : 'RECRUITMENT',
+      sort: pathname === '/recruitment' ? 'FormInfo.formCloseDateTime' : 'EventInfo.startDateTime',
+    },
+    pathname,
+  );
+
+  if (!pageData) {
+    return null;
+  }
+  const { totalPages, size } = pageData;
+
+  const handleChangePage = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <>
+      <EventsWrapper>
+        {events?.map(({ id, eventInfo, clubInfo }) => {
+          return (
+            <EventCard
+              key={id}
+              eventId={id}
+              posterSrc={eventInfo.posterImageUrl}
+              eventTitle={eventInfo.title}
+              startDate={eventInfo.startDate}
+              endDate={eventInfo.endDate}
+              location={eventInfo.location}
+              isEnded={eventInfo.isEnded}
+              clubName={clubInfo.name}
+              clubLogoImageUrl={clubInfo.logoImageUrl}
+            />
+          );
+        })}
+      </EventsWrapper>
+      <Pagination
+        totalPages={totalPages}
+        size={size}
+        onChangePage={handleChangePage}
+        currentPage={currentPage}
+      />
+    </>
+  );
+};
+
+export default MainEvents;

--- a/src/components/SearchedEvents.tsx
+++ b/src/components/SearchedEvents.tsx
@@ -1,0 +1,52 @@
+import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
+import { CommonEmptyEventsWrapper, EventsWrapper } from '@/styles/common';
+
+import { useState } from 'react';
+
+import EventCard from './common/EventCard/EventCard';
+import Pagination from './common/Pagination/Pagination';
+
+interface SearchedEventsProps {
+  keyword: string | undefined;
+}
+
+const SearchedEvents = ({ keyword }: SearchedEventsProps) => {
+  const [currentPage, setCurrentPage] = useState(0);
+  const { data, pageData } = useSearchResultQuery({ keyword: keyword ?? '', page: currentPage });
+  if (!pageData) {
+    return null;
+  }
+  const { totalPages, size } = pageData;
+
+  return (
+    <>
+      <EventsWrapper>
+        {data?.map(({ id, eventInfo, clubInfo }) => (
+          <EventCard
+            key={id}
+            eventId={id}
+            eventTitle={eventInfo.title}
+            startDate={eventInfo.startDate}
+            endDate={eventInfo.endDate}
+            posterSrc={eventInfo.posterImageUrl}
+            location={eventInfo.location}
+            clubName={clubInfo.name}
+            clubLogoImageUrl={clubInfo.logoImageUrl}
+            isEnded={eventInfo.isEnded}
+          />
+        ))}
+      </EventsWrapper>
+      {data?.length === 0 && (
+        <CommonEmptyEventsWrapper>검색결과가 없습니다.</CommonEmptyEventsWrapper>
+      )}
+      <Pagination
+        totalPages={totalPages}
+        size={size}
+        onChangePage={(page) => setCurrentPage(page)}
+        currentPage={currentPage}
+      />
+    </>
+  );
+};
+
+export default SearchedEvents;

--- a/src/components/common/Spinner/Spinner.style.ts
+++ b/src/components/common/Spinner/Spinner.style.ts
@@ -6,7 +6,7 @@ const SpinnerWrapper = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100%;
+  height: 40vh;
 `;
 
 const SpinnerStyled = styled.div<{ size: number }>`

--- a/src/hooks/query/club/useClubEventsQuery.ts
+++ b/src/hooks/query/club/useClubEventsQuery.ts
@@ -12,6 +12,7 @@ const useClubEventsQuery = ({ clubId, pageNumber, isSchedule }: GetClubEventsReq
     queryKey: [QUERY_KEY.CLUB_EVENTS, clubId, pageNumber],
     queryFn: () => getClubEvents({ clubId, pageNumber, isSchedule }),
     staleTime: CLUB_EVENTS_STALE_TIME,
+    suspense: true,
   });
 
   const { data, pageData } = events ?? {};

--- a/src/hooks/query/club/useGetClubQuery.ts
+++ b/src/hooks/query/club/useGetClubQuery.ts
@@ -13,6 +13,7 @@ const useGetClubQuery = ({ clubId, isEnabled = true }: GetClubRequest) => {
     queryFn: () => getClub({ clubId }),
     queryKey: [QUERY_KEY.GET_CLUB, clubId],
     enabled: isEnabled,
+    suspense: true,
   });
   return { clubInfo, refetch };
 };

--- a/src/hooks/query/event/useAllEventsQuery.ts
+++ b/src/hooks/query/event/useAllEventsQuery.ts
@@ -16,6 +16,7 @@ const useAllEventsQuery = ({ pageNumber, category, sort }: AllEventsRequest, pat
       pageNumber,
     ],
     queryFn: () => getAllEvents({ pageNumber, category, sort }),
+    suspense: true,
   });
 
   const { data, pageData } = allEvents ?? {};

--- a/src/hooks/query/event/useSearchResultQuery.ts
+++ b/src/hooks/query/event/useSearchResultQuery.ts
@@ -10,6 +10,7 @@ const useSearchResultQuery = ({ keyword, page }: SearchResultRequest) => {
     queryKey: [QUERY_KEY.SEARCH_RESULT, keyword, page],
     queryFn: () => getSearchResult({ keyword, page }),
     enabled: !!keyword,
+    suspense: true,
   });
 
   const { data, pageData } = searchResultData ?? {};

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,43 +1,16 @@
+import MainEvents from '@/components/MainEvents/MainEvents';
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
 import Banner from '@/components/common/Banner/Banner';
-import EventCard from '@/components/common/EventCard/EventCard';
 import Header from '@/components/common/Header/Header';
-import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
-import useAllEventsQuery from '@/hooks/query/event/useAllEventsQuery';
-import { EventsWrapper } from '@/styles/common';
 
-import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { BannerWrapperStyled, ContentContainerStyled } from './MainPage.style';
 
 const MainPage = () => {
   const { pathname } = useLocation();
-  const [currentPage, setCurrentPage] = useState(0);
-
-  useEffect(() => {
-    setCurrentPage(0);
-  }, [pathname]);
-
-  const { events, pageData } = useAllEventsQuery(
-    {
-      pageNumber: currentPage,
-      category: pathname === '/' ? 'SHOW' : pathname === '/events' ? 'PROMOTION' : 'RECRUITMENT',
-      sort: pathname === '/recruitment' ? 'FormInfo.formCloseDateTime' : 'EventInfo.startDateTime',
-    },
-    pathname,
-  );
-
-  if (!pageData) {
-    return null;
-  }
-  const { totalPages, size } = pageData;
-
-  const handleChangePage = (page: number) => {
-    setCurrentPage(page);
-  };
 
   return (
     <>
@@ -49,30 +22,7 @@ const MainPage = () => {
         <BannerWrapperStyled>
           <Banner width={35} height={20} />
         </BannerWrapperStyled>
-        <EventsWrapper>
-          {events?.map(({ id, eventInfo, clubInfo }) => {
-            return (
-              <EventCard
-                key={id}
-                eventId={id}
-                posterSrc={eventInfo.posterImageUrl}
-                eventTitle={eventInfo.title}
-                startDate={eventInfo.startDate}
-                endDate={eventInfo.endDate}
-                location={eventInfo.location}
-                isEnded={eventInfo.isEnded}
-                clubName={clubInfo.name}
-                clubLogoImageUrl={clubInfo.logoImageUrl}
-              />
-            );
-          })}
-        </EventsWrapper>
-        <Pagination
-          totalPages={totalPages}
-          size={size}
-          onChangePage={handleChangePage}
-          currentPage={currentPage}
-        />
+        <MainEvents pathname={pathname} />
       </ContentContainerStyled>
     </>
   );

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,4 +1,4 @@
-import MainEvents from '@/components/MainEvents/MainEvents';
+import MainEvents from '@/components/MainEvents';
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
 import Banner from '@/components/common/Banner/Banner';
 import Header from '@/components/common/Header/Header';

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -2,9 +2,11 @@ import MainEvents from '@/components/MainEvents/MainEvents';
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
 import Banner from '@/components/common/Banner/Banner';
 import Header from '@/components/common/Header/Header';
+import Spinner from '@/components/common/Spinner/Spinner';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
 
+import { Suspense } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { BannerWrapperStyled, ContentContainerStyled } from './MainPage.style';
@@ -22,7 +24,9 @@ const MainPage = () => {
         <BannerWrapperStyled>
           <Banner width={35} height={20} />
         </BannerWrapperStyled>
-        <MainEvents pathname={pathname} />
+        <Suspense fallback={<Spinner />}>
+          <MainEvents pathname={pathname} />
+        </Suspense>
       </ContentContainerStyled>
     </>
   );

--- a/src/pages/SearchResultPage/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage/SearchResultPage.tsx
@@ -1,25 +1,15 @@
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
-import EventCard from '@/components/common/EventCard/EventCard';
+import SearchedEvents from '@/components/SearchedEvents';
 import Header from '@/components/common/Header/Header';
-import Pagination from '@/components/common/Pagination/Pagination';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
-import useSearchResultQuery from '@/hooks/query/event/useSearchResultQuery';
-import { CommonEmptyEventsWrapper, EventsWrapper } from '@/styles/common';
 
-import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { SearchMessageStyled, SearchesContainer } from './SearchResultPage.style';
 
 const SearchResultPage = () => {
   const { keyword } = useParams();
-  const [currentPage, setCurrentPage] = useState(0);
-  const { data, pageData } = useSearchResultQuery({ keyword: keyword ?? '', page: currentPage });
-  if (!pageData) {
-    return null;
-  }
-  const { totalPages, size } = pageData;
 
   return (
     <>
@@ -29,31 +19,7 @@ const SearchResultPage = () => {
       </Header>
       <SearchMessageStyled>{`"${keyword}" 검색 결과`}</SearchMessageStyled>
       <SearchesContainer>
-        <EventsWrapper>
-          {data?.map(({ id, eventInfo, clubInfo }) => (
-            <EventCard
-              key={id}
-              eventId={id}
-              eventTitle={eventInfo.title}
-              startDate={eventInfo.startDate}
-              endDate={eventInfo.endDate}
-              posterSrc={eventInfo.posterImageUrl}
-              location={eventInfo.location}
-              clubName={clubInfo.name}
-              clubLogoImageUrl={clubInfo.logoImageUrl}
-              isEnded={eventInfo.isEnded}
-            />
-          ))}
-        </EventsWrapper>
-        {data?.length === 0 && (
-          <CommonEmptyEventsWrapper>검색결과가 없습니다.</CommonEmptyEventsWrapper>
-        )}
-        <Pagination
-          totalPages={totalPages}
-          size={size}
-          onChangePage={(page) => setCurrentPage(page)}
-          currentPage={currentPage}
-        />
+        <SearchedEvents keyword={keyword} />
       </SearchesContainer>
     </>
   );

--- a/src/pages/SearchResultPage/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage/SearchResultPage.tsx
@@ -1,9 +1,11 @@
 import SearchInputForm from '@/components/SearchInputForm/SearchInputForm';
 import SearchedEvents from '@/components/SearchedEvents';
 import Header from '@/components/common/Header/Header';
+import Spinner from '@/components/common/Spinner/Spinner';
 import Tab from '@/components/common/Tab/Tab';
 import { MAIN_TABS } from '@/constants/tab';
 
+import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { SearchMessageStyled, SearchesContainer } from './SearchResultPage.style';
@@ -18,9 +20,11 @@ const SearchResultPage = () => {
         <Tab tabItems={MAIN_TABS} />
       </Header>
       <SearchMessageStyled>{`"${keyword}" 검색 결과`}</SearchMessageStyled>
-      <SearchesContainer>
-        <SearchedEvents keyword={keyword} />
-      </SearchesContainer>
+      <Suspense fallback={<Spinner />}>
+        <SearchesContainer>
+          <SearchedEvents keyword={keyword} />
+        </SearchesContainer>
+      </Suspense>
     </>
   );
 };

--- a/src/pages/club/ClubEventPage/ClubEventPage.style.ts
+++ b/src/pages/club/ClubEventPage/ClubEventPage.style.ts
@@ -1,4 +1,3 @@
-import Theme from '@/styles/Theme';
 import styled from '@emotion/styled';
 
 const ContentSpacer = styled.div`
@@ -13,19 +12,10 @@ const ContentContainer = styled.div`
   height: 100%;
 `;
 
-const EmptyClubEvent = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  height: 60vh;
-  font-size: ${Theme.fontSize.mediumContent};
-`;
-
 const ButtonWrapper = styled.div`
   position: fixed;
   bottom: 3rem;
   right: 5rem;
 `;
 
-export { ContentContainer, ContentSpacer, ButtonWrapper, EmptyClubEvent };
+export { ContentContainer, ContentSpacer, ButtonWrapper };

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -1,9 +1,11 @@
 import ActiveButton from '@/components/ActiveButton/ActiveButton';
 import ClubEvents from '@/components/ClubEvents/ClubEvents';
 import ClubHeader from '@/components/ClubHeader/ClubHeader';
+import Spinner from '@/components/common/Spinner/Spinner';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
 
+import { Suspense } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { ButtonWrapper, ContentContainer, ContentSpacer } from './ClubEventPage.style';
@@ -17,9 +19,11 @@ const ClubEventPage = () => {
     <>
       <ClubHeader clubId={clubId}></ClubHeader>
       <ContentSpacer />
-      <ContentContainer>
-        <ClubEvents clubId={clubId} />
-      </ContentContainer>
+      <Suspense fallback={<Spinner />}>
+        <ContentContainer>
+          <ClubEvents clubId={clubId} />
+        </ContentContainer>
+      </Suspense>
       <ButtonWrapper>
         <ActiveButton
           buttonText={CREATE_EVENT.BUTTON_TEXT}

--- a/src/pages/club/ClubEventPage/ClubEventPage.tsx
+++ b/src/pages/club/ClubEventPage/ClubEventPage.tsx
@@ -1,71 +1,24 @@
 import ActiveButton from '@/components/ActiveButton/ActiveButton';
+import ClubEvents from '@/components/ClubEvents/ClubEvents';
 import ClubHeader from '@/components/ClubHeader/ClubHeader';
-import EventCard from '@/components/common/EventCard/EventCard';
-import Pagination from '@/components/common/Pagination/Pagination';
 import { CREATE_EVENT } from '@/constants/club';
 import { PATH } from '@/constants/path';
-import useClubEventsQuery from '@/hooks/query/club/useClubEventsQuery';
-import { CommonEmptyEventsWrapper, EventsWrapper } from '@/styles/common';
 
-import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import {
-  ButtonWrapper,
-  ContentContainer,
-  ContentSpacer,
-  EmptyClubEvent,
-} from './ClubEventPage.style';
+import { ButtonWrapper, ContentContainer, ContentSpacer } from './ClubEventPage.style';
 
 const ClubEventPage = () => {
   const navigate = useNavigate();
-  const [currentPage, setCurrentPage] = useState(0);
   const { clubId } = useParams();
   if (!clubId) throw new Error('클럽 ID를 찾을 수 없습니다');
-  const { clubEvents, pageData } = useClubEventsQuery({ clubId, pageNumber: currentPage });
-  if (!pageData) {
-    return null;
-  }
-
-  const { totalPages, size } = pageData;
-
-  const handleChangePage = (page: number) => {
-    setCurrentPage(page);
-  };
 
   return (
     <>
       <ClubHeader clubId={clubId}></ClubHeader>
       <ContentSpacer />
       <ContentContainer>
-        <EventsWrapper>
-          {clubEvents?.map(({ id, eventInfo, clubInfo }) => (
-            <EventCard
-              key={id}
-              eventId={id}
-              posterSrc={eventInfo.posterImageUrl}
-              eventTitle={eventInfo.title}
-              startDate={eventInfo.startDate}
-              endDate={eventInfo.endDate}
-              location={eventInfo.location}
-              clubLogoImageUrl={clubInfo.logoImageUrl}
-              clubName={clubInfo.name}
-              openStatus={eventInfo.openStatus}
-              isEnded={eventInfo.isEnded}
-            />
-          ))}
-        </EventsWrapper>
-        {clubEvents?.length === 0 && (
-          <CommonEmptyEventsWrapper>
-            <EmptyClubEvent>클럽에서 생성한 행사가 없습니다!</EmptyClubEvent>
-          </CommonEmptyEventsWrapper>
-        )}
-        <Pagination
-          totalPages={totalPages}
-          size={size}
-          onChangePage={handleChangePage}
-          currentPage={currentPage}
-        />
+        <ClubEvents clubId={clubId} />
       </ContentContainer>
       <ButtonWrapper>
         <ActiveButton

--- a/src/pages/club/ClubManagePage/ClubManagePage.tsx
+++ b/src/pages/club/ClubManagePage/ClubManagePage.tsx
@@ -6,7 +6,6 @@ import ConfirmModal from '@/components/Modals/ConfirmModal';
 import Spinner from '@/components/common/Spinner/Spinner';
 import { MODAL_TEXT } from '@/constants/modalMessage';
 import useDeleteClubMutation from '@/hooks/query/club/useDeleteClubMutation';
-import useGetClubQuery from '@/hooks/query/club/useGetClubQuery';
 import useModal from '@/hooks/useModal';
 
 import { Suspense } from 'react';
@@ -32,9 +31,6 @@ const ClubManagePage = () => {
   }
 
   const { deleteClubMutate } = useDeleteClubMutation({ clubId });
-
-  const { clubInfo } = useGetClubQuery({ clubId });
-  if (!clubInfo) return null;
 
   return (
     <>


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 메인페이지, 클럽행사페이지, 검색결과페이지의 events들을 컴포넌트로 분리하였습니다.
- 메인페이지, 클럽행사페이지, 검색결과페이지, 클럽폼페이지, 클럽관리페이지에 suspense를 적용하였습니다. 
- 적용하지 않은 페이지의 경우 쿼리 훅을 사용하는 컴포넌트로 분리되지 않아 suspense 처리를 할 수 없기 때문입니다! suspense 처리가 필요할 경우 담당한 페이지에서 컴포넌트로 만들고 추가하시면 되겠습니다.
- 이제 진짜 안 날 겁니다..오류.......

## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



