### PR TITLE
SKRF-439 design: 포스터이미지 없을 시 아이콘 띄우기

### DIFF
--- a/src/components/common/Poster/Poster.tsx
+++ b/src/components/common/Poster/Poster.tsx
@@ -3,7 +3,7 @@ import { BsFillFileImageFill } from 'react-icons/bs';
 import { PosterAreaStyled, PosterStyled, TagStyled } from './Poster.style';
 
 interface PosterProps {
-  posterSrc?: string;
+  posterSrc?: string | null;
   width?: number;
   isEnded?: boolean;
   children?: React.ReactNode;
@@ -12,8 +12,11 @@ interface PosterProps {
 const Poster = ({ posterSrc, width = 12, isEnded, children }: PosterProps) => {
   return (
     <PosterAreaStyled width={width} isEnded={isEnded}>
-      <PosterStyled src={posterSrc} alt="poster image" />
-      {!posterSrc && <BsFillFileImageFill size={3.5} />}
+      {posterSrc ? (
+        <PosterStyled src={posterSrc} alt="poster image" />
+      ) : (
+        <BsFillFileImageFill size={100} />
+      )}
       <TagStyled>{children}</TagStyled>
     </PosterAreaStyled>
   );


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 포스터이미지 없을 시 아이콘 띄우기를 햇씁니다. 우선 아이콘은 임시입니다. 

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/98521882/fc64375a-1336-4698-bf47-b86b55de9e6d)

## ✨pr포인트 & 궁금한 점 



