### PR TITLE
SKRF-453 design: 일정생성자 사진과 이름 살짝 띄움

### DIFF
--- a/src/components/Schedule/Schedule.style.ts
+++ b/src/components/Schedule/Schedule.style.ts
@@ -29,6 +29,7 @@ const ScheduleContentStyled = styled.span`
 const WriterInfoWrapper = styled.div`
   display: flex;
   align-items: start;
+  gap: 0.2rem;
   position: absolute;
   right: 1rem;
   bottom: 0.5rem;


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 클럽홈페이지의 클럽일정 영역에서 일정생성자 이름과 사진 사이에 살짝 공간을 주었습니다. 
원래는 딱 붙어 있었어요
  
## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/98521882/9ad96232-152d-43e9-858c-a172ebf1e662)

## ✨pr포인트 & 궁금한 점 



