### PR TITLE
SKRF-469 design: 탭, 포스터 텍스트 white-space:nowrap처리

### DIFF
--- a/src/components/common/Poster/Poster.style.ts
+++ b/src/components/common/Poster/Poster.style.ts
@@ -31,7 +31,7 @@ const PosterAreaStyled = styled.div<{ width: number; isEnded?: boolean }>`
     left: 50%;
     transform: translate(-50%, -50%);
     color: white;
-    font-size: ${Theme.fontSize.smallContent};
+    font-size: ${Theme.fontSize.tagText};
     text-align: center;
     display: ${({ isEnded }) => (isEnded ? 'block' : 'none')};
     white-space: nowrap;

--- a/src/components/common/Poster/Poster.style.ts
+++ b/src/components/common/Poster/Poster.style.ts
@@ -34,6 +34,7 @@ const PosterAreaStyled = styled.div<{ width: number; isEnded?: boolean }>`
     font-size: ${Theme.fontSize.smallContent};
     text-align: center;
     display: ${({ isEnded }) => (isEnded ? 'block' : 'none')};
+    white-space: nowrap;
   }
 `;
 

--- a/src/components/common/Tab/Tab.style.ts
+++ b/src/components/common/Tab/Tab.style.ts
@@ -16,6 +16,7 @@ const TabItemStyled = styled.div<{ isActive: boolean }>`
   line-height: 2rem;
   color: ${(props) => (props.isActive ? `${Theme.color.activeColor}` : `${Theme.color.black}`)};
   cursor: pointer;
+  white-space: nowrap;
 
   &:not(:last-of-type)::after {
     content: '';


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 탭, 포스터 텍스트 white-space:nowrap처리

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/98521882/1f829f96-ec26-4eaf-8665-4249760dc814)

## ✨pr포인트 & 궁금한 점 



