### PR TITLE
SKRF0470 행사정보작성페이지 QA 3차

### DIFF
--- a/src/components/ManagerButton/ManagerButton.tsx
+++ b/src/components/ManagerButton/ManagerButton.tsx
@@ -11,15 +11,16 @@ import { getEventDetailResponse } from '@/types/api/getEventDetail';
 import { useNavigate } from 'react-router-dom';
 
 interface ManagerButton {
+  isToken: boolean;
   eventId: string;
   eventDetail: getEventDetailResponse;
   deleteModalOpen: () => void;
 }
 
-const ManagerButton = ({ eventId, eventDetail, deleteModalOpen }: ManagerButton) => {
+const ManagerButton = ({ isToken, eventId, eventDetail, deleteModalOpen }: ManagerButton) => {
   const { clubInfo, hasForm } = eventDetail;
   const { clubId } = clubInfo;
-  const { role } = useMemberAuth({ clubId });
+  const { role } = useMemberAuth({ clubId, isEnabled: isToken });
   const navigate = useNavigate();
 
   return (

--- a/src/components/PerformanceForm/PerformanceForm.tsx
+++ b/src/components/PerformanceForm/PerformanceForm.tsx
@@ -73,7 +73,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
           {...register('startDate', {
             required: REQUIRED('공연 시작 날짜는'),
             validate: {
-              today: validateTodayDate,
+              today: (value) => (eventDetail ? true : validateTodayDate(value)),
               compare: (value) =>
                 validateTimeCompare(watch('closeDate'), value, FORM_START_TIME('공연')),
             },
@@ -185,7 +185,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
             {...register('openDate', {
               required: REQUIRED('신청 시작 날짜는'),
               validate: {
-                today: validateTodayDate,
+                today: (value) => (eventDetail ? true : validateTodayDate(value)),
                 compare: (value) => validateTimeCompare(value, watch('closeDate'), LAST_TIME),
               },
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },

--- a/src/components/PerformanceForm/PerformanceForm.tsx
+++ b/src/components/PerformanceForm/PerformanceForm.tsx
@@ -234,6 +234,7 @@ const PerformanceForm = ({ register, setValue, watch, errors, eventDetail }: Per
           labelText="공연 내용 작성"
           required
           rows={10}
+          maxLength={LIMIT_LENGTH.CONTENT_MAX}
         />
         {errors.content && <ErrorMessage>{errors.content?.message as string}</ErrorMessage>}
       </ContentArea>

--- a/src/components/PromotionForm/PromotionForm.tsx
+++ b/src/components/PromotionForm/PromotionForm.tsx
@@ -158,6 +158,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
           labelText="행사 내용 작성"
           required
           rows={10}
+          maxLength={LIMIT_LENGTH.CONTENT_MAX}
         />
         {errors.content && <ErrorMessage>{errors.content?.message as string}</ErrorMessage>}
       </ContentArea>

--- a/src/components/PromotionForm/PromotionForm.tsx
+++ b/src/components/PromotionForm/PromotionForm.tsx
@@ -62,7 +62,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
           {...register('startDate', {
             required: REQUIRED('행사 시작 날짜는'),
             validate: {
-              today: validateTodayDate,
+              today: (value) => (eventDetail ? true : validateTodayDate(value)),
               compare: (value) =>
                 validateTimeCompare(watch('closeDate'), value, FORM_START_TIME('행사')),
             },
@@ -109,7 +109,7 @@ const PromotionForm = ({ register, setValue, watch, errors, eventDetail }: Promo
             {...register('openDate', {
               required: REQUIRED('신청 시작 날짜는'),
               validate: {
-                today: validateTodayDate,
+                today: (value) => (eventDetail ? true : validateTodayDate(value)),
                 compare: (value) => validateTimeCompare(value, watch('closeDate'), LAST_TIME),
               },
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },

--- a/src/components/RecruitForm/RecruitForm.tsx
+++ b/src/components/RecruitForm/RecruitForm.tsx
@@ -156,6 +156,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
           labelText="공고 내용"
           required
           rows={10}
+          maxLength={LIMIT_LENGTH.CONTENT_MAX}
         />
         {errors.content && <ErrorMessage>{errors.content.message as string}</ErrorMessage>}
       </ContentArea>

--- a/src/components/RecruitForm/RecruitForm.tsx
+++ b/src/components/RecruitForm/RecruitForm.tsx
@@ -107,7 +107,7 @@ const RecruitForm = ({ register, setValue, watch, errors, eventDetail }: Recruit
             {...register('openDate', {
               required: REQUIRED('신청 시작 날짜는'),
               validate: {
-                today: validateTodayDate,
+                today: (value) => (eventDetail ? true : validateTodayDate(value)),
                 compare: (value) => validateTimeCompare(value, watch('closeDate'), LAST_TIME),
               },
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },

--- a/src/components/ScheduleForm/ScheduleForm.tsx
+++ b/src/components/ScheduleForm/ScheduleForm.tsx
@@ -64,7 +64,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             {...register('startDate', {
               required: REQUIRED('활동 시작 날짜는'),
               validate: {
-                today: validateTodayDate,
+                today: (value) => (eventDetail ? true : validateTodayDate(value)),
                 compare: (value) => validateTimeCompare(value, watch('endDate'), LAST_TIME),
                 compareForm: (value) =>
                   validateTimeCompare(watch('closeDate'), value, FORM_START_TIME('활동')),
@@ -143,7 +143,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
             {...register('openDate', {
               required: REQUIRED('신청 시작 날짜는'),
               validate: {
-                today: validateTodayDate,
+                today: (value) => (eventDetail ? true : validateTodayDate(value)),
                 compare: (value) => validateTimeCompare(value, watch('closeDate'), LAST_TIME),
               },
               max: { value: LIMIT_VALUE.DATE_MAX, message: MAX_YEAR },

--- a/src/components/ScheduleForm/ScheduleForm.tsx
+++ b/src/components/ScheduleForm/ScheduleForm.tsx
@@ -190,6 +190,7 @@ const ScheduleForm = ({ register, setValue, watch, errors, eventDetail }: Schedu
           })}
           labelText="일정 안내"
           rows={10}
+          maxLength={LIMIT_LENGTH.CONTENT_MAX}
         />
         {errors.content && <ErrorMessage>{errors.content.message as string}</ErrorMessage>}
       </ContentArea>

--- a/src/components/UserApplyButton/UserApplyButton.tsx
+++ b/src/components/UserApplyButton/UserApplyButton.tsx
@@ -27,7 +27,7 @@ const UserApplyButton = ({
   loginModalOpen,
 }: UserApplyButton) => {
   const bookmarkRef = useRef<HTMLDivElement>(null);
-  const { isBookmarked } = useIsBookmarkedQuery({ eventId });
+  const { isBookmarked } = useIsBookmarkedQuery({ eventId, isEnabled: isToken });
   const { category, hasAlreadyApplied, eventInfo, formInfo } = eventDetail ?? {};
   const { applicants, isEnded } = eventInfo ?? {};
   const { isAbleToApply } = formInfo ?? {};

--- a/src/components/UserApplyButton/UserApplyButton.tsx
+++ b/src/components/UserApplyButton/UserApplyButton.tsx
@@ -60,7 +60,7 @@ const UserApplyButton = ({
 
   return (
     <ButtonWrapper>
-      {capacity && (
+      {capacity && category !== 'RECRUITMENT' && (
         <ApplicantButton
           reverse
           capacity={Boolean(capacity)}
@@ -71,7 +71,7 @@ const UserApplyButton = ({
         </ApplicantButton>
       )}
       <ApplyButton
-        capacity={Boolean(capacity)}
+        capacity={Boolean(category !== 'RECRUITMENT' && capacity)}
         disabled={getApplyButtonText() !== EVENT_DETAIL_BUTTON.APPLY.POSSIBLE}
         onClick={() => (isToken ? applyModalOpen() : loginModalOpen())}
       >

--- a/src/hooks/query/event/useIsBookmarkedQuery.ts
+++ b/src/hooks/query/event/useIsBookmarkedQuery.ts
@@ -1,14 +1,19 @@
 import getIsBookmark from '@/apis/event/getIsBookmark';
-import { GetIsBookmarkRequest } from '@/types/api/getIsBookmark';
 
 import { useQuery } from '@tanstack/react-query';
 
 export const QUERY_KEY = { GET_IS_BOOKMARKED: 'GET_IS_BOOKMARKED' };
 
-const useIsBookmarkedQuery = ({ eventId }: GetIsBookmarkRequest) => {
+interface UseIsBookmarkedQuery {
+  eventId: string;
+  isEnabled?: boolean;
+}
+
+const useIsBookmarkedQuery = ({ eventId, isEnabled }: UseIsBookmarkedQuery) => {
   const { data: isBookmarked } = useQuery({
     queryFn: () => getIsBookmark({ eventId }),
     queryKey: [QUERY_KEY, eventId],
+    enabled: isEnabled,
   });
 
   return { isBookmarked };

--- a/src/hooks/query/event/usePostEventInfoMutation.ts
+++ b/src/hooks/query/event/usePostEventInfoMutation.ts
@@ -1,7 +1,6 @@
 import postPerformanceForm from '@/apis/event/postPerformanceForm';
 import { PATH } from '@/constants/path';
-import useImageException from '@/hooks/useImageException';
-import useTextException from '@/hooks/useTextException';
+import useException from '@/hooks/useException';
 import { HttpException } from '@/types/common';
 import { FormPage } from '@/types/event';
 
@@ -17,8 +16,7 @@ import { QUERY_KEY as ALL_EVENTS_QUERY_KEY } from './useAllEventsQuery';
 const usePostEventInfoMutation = ({ eventType, clubId, isEdit }: FormPage) => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { handleTextException } = useTextException();
-  const { handleImageException } = useImageException();
+  const { handleException } = useException({ defaultMessage: '정보 작성에 실패했습니다.' });
 
   const { mutate: submitForm, isLoading: isSubmitLoading } = useMutation({
     mutationFn: postPerformanceForm,
@@ -38,8 +36,7 @@ const usePostEventInfoMutation = ({ eventType, clubId, isEdit }: FormPage) => {
       ]);
     },
     onError: (error: AxiosError<HttpException>) => {
-      handleTextException(error);
-      handleImageException(error);
+      handleException(error);
     },
   });
   return { submitForm, isSubmitLoading };

--- a/src/hooks/useException.ts
+++ b/src/hooks/useException.ts
@@ -1,0 +1,34 @@
+import { EXCEPTION_CODE, EXCEPTION_CODE_MESSAGE } from '@/constants/exceptionCode';
+import { HttpException } from '@/types/common';
+
+import { AxiosError } from 'axios';
+
+import useToast from './useToast';
+
+interface UseException {
+  defaultMessage: string;
+}
+
+const useException = ({ defaultMessage }: UseException) => {
+  const { createToast } = useToast();
+
+  const handleException = (error: AxiosError<HttpException>) => {
+    if (!error.response) {
+      createToast({ message: defaultMessage, toastType: 'error' });
+      return;
+    }
+
+    if (Object.values(EXCEPTION_CODE).find((code) => code === error.response?.data.code)) {
+      createToast({
+        message: EXCEPTION_CODE_MESSAGE[error.response?.data.code],
+        toastType: 'error',
+      });
+    } else {
+      createToast({ message: defaultMessage, toastType: 'error' });
+    }
+  };
+
+  return { handleException };
+};
+
+export default useException;

--- a/src/pages/event/EventDetailPage/CategoryDetail/CategoryDetailForm.tsx
+++ b/src/pages/event/EventDetailPage/CategoryDetail/CategoryDetailForm.tsx
@@ -2,7 +2,7 @@ import { EVENT_DETAIL } from '@/constants/event';
 import { getEventDetailResponse } from '@/types/api/getEventDetail';
 import { transDate, transTime } from '@/utils/timeTransform';
 
-import { ContentLabel, EventTitle } from '../EventDetailPage.style';
+import { ContentLabel, EventRow, EventTitle } from '../EventDetailPage.style';
 import ClubDetail from './ClubDetail';
 import PromotionDetail from './PromotionDetail';
 import RecruitmentDetail from './RecruitmentDetail';
@@ -33,17 +33,17 @@ const CategoryDetailForm = ({ data }: CategoryDetailForm) => {
     <>
       <EventTitle>{eventInfo.title}</EventTitle>
       {renderCategory()}
-      <div>
+      <EventRow>
         <ContentLabel>{EVENT_DETAIL.APPLICATION_PERIOD}</ContentLabel>
         <div>
           {transDate(openDate)} {transTime(openTime)} ~ {transDate(closeDate)}{' '}
           {transTime(closeTime)}까지
         </div>
-      </div>
-      <div>
+      </EventRow>
+      <EventRow>
         <ContentLabel>{EVENT_DETAIL.ORGANIZER}</ContentLabel>
         {clubInfo.clubName}
-      </div>
+      </EventRow>
     </>
   );
 };

--- a/src/pages/event/EventDetailPage/EventDetailPage.style.ts
+++ b/src/pages/event/EventDetailPage/EventDetailPage.style.ts
@@ -36,10 +36,7 @@ const EventDetailWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-
-  @media (max-width: 1023px) {
-    justify-content: center;
-  }
+  justify-content: center;
 `;
 const DetailContentWrapper = styled.div`
   display: flex;
@@ -51,6 +48,15 @@ const DetailContentWrapper = styled.div`
 `;
 const EventTitle = styled.div`
   font-size: ${Theme.fontSize.largeTitle};
+
+  @media (max-width: 1023px) {
+    margin: 1rem 0;
+  }
+`;
+const EventRow = styled.div`
+  @media (max-width: 1023px) {
+    margin-top: 1rem;
+  }
 `;
 const TwoContentWrapper = styled.div<{ itemLength: number }>`
   display: ${({ itemLength }) => (itemLength === 0 ? 'none' : 'grid')};
@@ -59,7 +65,7 @@ const TwoContentWrapper = styled.div<{ itemLength: number }>`
   gap: 3rem;
 
   @media (max-width: 1023px) {
-    gap: 0;
+    gap: 1rem;
   }
 `;
 const ContentLabel = styled.div`
@@ -110,10 +116,13 @@ const EventContentTitle = styled.div`
   font-size: ${Theme.fontSize.largeTitle};
   padding: 1rem 0;
 `;
-const EventContent = styled.textarea`
+const EventContent = styled.div`
   width: 100%;
-  border: none;
-  outline: none;
+  min-height: 30rem;
+  background-color: ${Theme.color.tWhiteGrey};
+  border-radius: 0.25rem;
+  padding: 1rem;
+  white-space: pre-wrap;
 `;
 
 export {
@@ -125,6 +134,7 @@ export {
   EventDetailWrapper,
   DetailContentWrapper,
   EventTitle,
+  EventRow,
   TwoContentWrapper,
   ContentLabel,
   ButtonWrapper,

--- a/src/pages/event/EventDetailPage/EventDetailPage.style.ts
+++ b/src/pages/event/EventDetailPage/EventDetailPage.style.ts
@@ -119,7 +119,7 @@ const EventContentTitle = styled.div`
 const EventContent = styled.div`
   width: 100%;
   min-height: 30rem;
-  background-color: ${Theme.color.tWhiteGrey};
+  background-color: ${Theme.color.tButtonWhite};
   border-radius: 0.25rem;
   padding: 1rem;
   white-space: pre-wrap;

--- a/src/pages/event/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/event/EventDetailPage/EventDetailPage.tsx
@@ -103,6 +103,7 @@ const EventDetailPage = () => {
           <Breadcrumb eventId={eventId} pageType="eventDetail" />
           <ContentWrapper>
             <ManagerButton
+              isToken={Boolean(token)}
               eventId={eventId}
               eventDetail={eventDetail!}
               deleteModalOpen={deleteModalOpen}

--- a/src/utils/timeTransform.ts
+++ b/src/utils/timeTransform.ts
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
 const transDate = (date: string) => moment(date, 'YYYY-MM-DD').format('YYYY년 MM월 DD일');
-const transTime = (date: string) => moment(date, 'HH-mm-ss').format('A hh:00');
+const transTime = (date: string) => moment(date, 'HH-mm-ss').format('A hh:mm');
 
 export { transDate, transTime };

--- a/src/utils/validate.ts
+++ b/src/utils/validate.ts
@@ -15,9 +15,10 @@ const validateTrim = (input: string) => {
   else return true;
 };
 
-const validateLarger = (small: number, big: number, smallText: string, bigText: string) => {
-  if (small > big) return LARGER(smallText, bigText);
-  else return true;
+const validateLarger = (small: string, big: string, smallText: string, bigText: string) => {
+  if (parseInt(small) > parseInt(big)) {
+    return LARGER(smallText, bigText);
+  } else return true;
 };
 
 const validateName = (input: string) => {


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 작업 내용 1: 행사 생성 시 행사 내용 maxLength 설정하기
- 작업 내용 2: 정보작성 실패시 toast띄워주기
- 작업 내용 3: 수정할 때 정보작성 폼 validation 무효화하기
- 작업 내용 4: 행사상세페이지 모집공고 지원현황 안 보여주기
- 작업 내용 5: 상페페이지 비로그인시 매니저 여부와 북마크 여부 보내지 않도록 하기
- 작업 내용 6: 상세페이지 행사 내용 content 변경

## 구현 스크린샷
<img width="362" alt="스크린샷 2023-12-02 오전 1 13 29" src="https://github.com/Space-Club/Frontend/assets/44944877/7a7165e2-aa1c-4835-80af-9d337fdafdce">

## ✨pr포인트 & 궁금한 점 
행사 내용이 밑으로 안 가고 같이 있으면 모양이 이상해지네요ㅠㅡㅠ 밑에 행사 내용 디자인을 어떻게 해야할지 잘 모르겠네요..

