### PR TITLE
SKRF-473 fix: 참여신청한 행사 취소요청 혹은 취소 시 제출된 폼 QUERYKEY무효화

### DIFF
--- a/src/hooks/query/event/useCancelEventMutation.ts
+++ b/src/hooks/query/event/useCancelEventMutation.ts
@@ -6,6 +6,7 @@ import useToast from '@/hooks/useToast';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { QUERY_KEY } from './useAppliedEventQuery';
+import { QUERY_KEY as SUBMITTED_FORM_QUERY_KEY } from './useGetSubmittedFormsQuery';
 
 const useCancelEventMutation = () => {
   const { createToast } = useToast();
@@ -25,7 +26,10 @@ const useCancelEventMutation = () => {
         throw new Error('취소 요청 후 이벤트 상태가 CANCEL_REQUESTED 또는 CANCELED가 아닙니다');
       }
 
-      queryClient.invalidateQueries([QUERY_KEY.APPLIED_EVENT]);
+      Promise.all([
+        queryClient.invalidateQueries([QUERY_KEY.APPLIED_EVENT]),
+        queryClient.invalidateQueries([SUBMITTED_FORM_QUERY_KEY.SUBMITTED_FORMS]),
+      ]);
     },
     onError: () => {
       createToast({ message: ERROR_MESSAGE.EVENT.CANCEL, toastType: 'error' });


### PR DESCRIPTION
## 📝요구사항과 구현내용
- 참여신청한 행사에 대해 취소/취소요청을 보내면 제출된 폼의 queryKey를 무효화합니다. 

## 구현 스크린샷

## ✨pr포인트 & 궁금한 점 



