### PR TITLE
Refactor : 프로필 페이지 내 Poster image에 lazy load 추가 및, 프로필 페이지 코드 청크 분할

### DIFF
--- a/src/components/BookmarkedCard/BookmarkedCard.tsx
+++ b/src/components/BookmarkedCard/BookmarkedCard.tsx
@@ -33,7 +33,7 @@ const BookmarkedCard = ({
       }}
     >
       <BookmarkedCardImageWrapper>
-        <Poster posterSrc={posterImageUrl} width={7.6} />
+        <Poster isLazy posterSrc={posterImageUrl} width={7.6} />
       </BookmarkedCardImageWrapper>
       <BookmarkedInfoWrapper>
         <BookmarkedTitleStyled>{title}</BookmarkedTitleStyled>

--- a/src/components/common/AppliedEventCard/AppliedEventCard.tsx
+++ b/src/components/common/AppliedEventCard/AppliedEventCard.tsx
@@ -37,7 +37,7 @@ const AppliedEventCard = ({
   return (
     <AppliedEventCardContainer {...props}>
       <EventLeftSection onClick={() => navigate(PATH.EVENT.DETAIL(eventId))}>
-        <Poster posterSrc={posterImageUrl} width={7.6} />
+        <Poster isLazy posterSrc={posterImageUrl} width={7.6} />
         <AppliedEventInfo
           eventId={eventId}
           title={title}

--- a/src/components/common/Poster/Poster.tsx
+++ b/src/components/common/Poster/Poster.tsx
@@ -1,22 +1,27 @@
+import useLazyImage from '@/hooks/useLazyImage';
+
 import { BsFillFileImageFill } from 'react-icons/bs';
 
 import { PosterAreaStyled, PosterStyled, TagStyled } from './Poster.style';
 
 interface PosterProps {
-  posterSrc?: string | null;
+  posterSrc?: string;
   width?: number;
   isEnded?: boolean;
+  isLazy?: boolean;
   children?: React.ReactNode;
 }
 
-const Poster = ({ posterSrc, width = 12, isEnded, children }: PosterProps) => {
+const Poster = ({ posterSrc, width = 12, isEnded, isLazy = false, children }: PosterProps) => {
+  const { imageSrc, targetRef } = useLazyImage({
+    isLazy,
+    completeImgSrc: posterSrc || '',
+  });
+
   return (
     <PosterAreaStyled width={width} isEnded={isEnded}>
-      {posterSrc ? (
-        <PosterStyled src={posterSrc} alt="poster image" />
-      ) : (
-        <BsFillFileImageFill size={100} />
-      )}
+      <PosterStyled ref={targetRef} src={imageSrc} alt="poster image" />
+      <BsFillFileImageFill size={100} />
       <TagStyled>{children}</TagStyled>
     </PosterAreaStyled>
   );

--- a/src/components/common/Skeleton/ProfileSkeleton.tsx
+++ b/src/components/common/Skeleton/ProfileSkeleton.tsx
@@ -1,0 +1,13 @@
+import Header from '../Header/Header';
+import Spinner from '../Spinner/Spinner';
+
+const ProfileSkeleton = () => {
+  return (
+    <>
+      <Header />
+      <Spinner />
+    </>
+  );
+};
+
+export default ProfileSkeleton;

--- a/src/hooks/useCarousel.ts
+++ b/src/hooks/useCarousel.ts
@@ -59,7 +59,7 @@ const useCarousel = ({ totalItem, autoSlide = false }: UseCarouselProps) => {
     } else if (currentIndex < 0) {
       setCurrentIndex(0);
     }
-  }, [totalItem, currentIndex]);
+  }, [totalItem]); //eslint-disable-line
 
   return {
     goNext,

--- a/src/hooks/useIsIntersecting.ts
+++ b/src/hooks/useIsIntersecting.ts
@@ -1,5 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 
+// useIsIntersection은 타겟 엘리먼트의 가시성을 검사합니다.
+// @params {HTMLElement} root: 옵션, 타겟의 가시성을 검사하기 위해 뷰포트 대신 사용할 요소 객체, 기본값은 뷰포트입니다.
+// @params {string} rootMargin: Root 범위를 확장하거나 축소하기 위한 마진 값, 기본값은 '0px 0px 0px 0px'입니다.
+// @params {number} threshold: 옵저버 콜백이 실행되는 타겟 엘리먼트의 가시성 비율, 기본값은 0입니다.
+// @returns {boolean} isIntersection: 타겟 엘리먼트가 뷰포트에 들어오면 true를 반환합니다.
+// @returns {RefObject} targetRef: 타겟 엘리먼트의 ref
+
 interface UseIsIntersectionProps {
   root?: HTMLElement;
   rootMargin?: string;

--- a/src/hooks/useIsIntersecting.ts
+++ b/src/hooks/useIsIntersecting.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface UseIsIntersectionProps {
+  root?: HTMLElement;
+  rootMargin?: string;
+  threshold?: number | number[];
+}
+
+const useIsIntersection = ({ root, rootMargin, threshold }: UseIsIntersectionProps) => {
+  const [isIntersection, setIsIntersection] = useState(false);
+  const targetRef = useRef(null);
+
+  const callback = (entries: IntersectionObserverEntry[]) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        setIsIntersection(true);
+      } else {
+        setIsIntersection(false);
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(callback, {
+    root,
+    rootMargin,
+    threshold,
+  });
+
+  useEffect(() => {
+    const targetElement = targetRef.current;
+    targetElement && observer.observe(targetElement);
+    return () => {
+      targetElement && observer.unobserve(targetElement);
+    };
+  }, [targetRef]); //eslint-disable-line
+
+  return { isIntersection, targetRef };
+};
+
+export default useIsIntersection;

--- a/src/hooks/useLazyImage.ts
+++ b/src/hooks/useLazyImage.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+import useIsIntersection from './useIsIntersecting';
+
+interface UseLazyImageProps {
+  isLazy?: boolean;
+  loadingImgSrc?: string;
+  completeImgSrc: string;
+}
+
+const useLazyImage = ({ loadingImgSrc, completeImgSrc, isLazy }: UseLazyImageProps) => {
+  const [imageSrc, setImageSrc] = useState<string>(loadingImgSrc ?? '');
+  const { isIntersection, targetRef } = useIsIntersection({});
+
+  useEffect(() => {
+    if (isIntersection) {
+      setImageSrc(completeImgSrc);
+    }
+  }, [isIntersection]); //eslint-disable-line
+
+  if (!isLazy) return { imageSrc: completeImgSrc, targetRef };
+
+  return { imageSrc, targetRef };
+};
+
+export default useLazyImage;

--- a/src/hooks/useLazyImage.ts
+++ b/src/hooks/useLazyImage.ts
@@ -8,6 +8,13 @@ interface UseLazyImageProps {
   completeImgSrc: string;
 }
 
+// useLazyImage는 이미지의 가시성을 검사하여 상황에 따라 적절한 이미지 src를 반환합니다.
+// @params {boolean} isLazy: true면 lazyLoad합니다. false면 일반 이미지 로딩
+// @params {string} loadingImgSrc: lazyLoad시 보여줄 로딩 이미지.
+// @params {string} completeImgSrc: lazyLoad시 로딩이 완료되면 보여줄 이미지.
+// @returns {string} imageSrc: 로딩 상태에 completeImgSrc, loadingImgSrc 중 하나를 할당합니다.
+// @returns {RefObject} targetRef: lazyLoad시 보여줄 이미지의 ref
+
 const useLazyImage = ({ loadingImgSrc, completeImgSrc, isLazy }: UseLazyImageProps) => {
   const [imageSrc, setImageSrc] = useState<string>(loadingImgSrc ?? '');
   const { isIntersection, targetRef } = useIsIntersection({});

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,12 +1,10 @@
 import DeleteUserButton from '@/components/DeleteUserButton/DeleteUserButton';
 import Profile from '@/components/Profile/Profile';
 import Header from '@/components/common/Header/Header';
-import Spinner from '@/components/common/Spinner/Spinner';
 import Tab from '@/components/common/Tab/Tab';
 import { PROFILE_TABS } from '@/constants/tab';
 import { ProfileEventType } from '@/types/event';
 
-import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 
 import AppliedEvents from './AppliedEvents';
@@ -27,15 +25,13 @@ const ProfilePage = () => {
           <DeleteUserButton />
         </DeleteUserButtonWrapper>
       </Header>
-      <Suspense fallback={<Spinner />}>
-        <Profile />
-        <ProfileBottomWrapper>
-          <AppliedEventTabContainer>
-            <Tab tabItems={PROFILE_TABS} />
-          </AppliedEventTabContainer>
-          {category === 'applied' ? <AppliedEvents /> : <BookmarkedEvents />}
-        </ProfileBottomWrapper>
-      </Suspense>
+      <Profile />
+      <ProfileBottomWrapper>
+        <AppliedEventTabContainer>
+          <Tab tabItems={PROFILE_TABS} />
+        </AppliedEventTabContainer>
+        {category === 'applied' ? <AppliedEvents /> : <BookmarkedEvents />}
+      </ProfileBottomWrapper>
     </>
   );
 };

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,11 +1,11 @@
 import App from '@/App';
+import ProfileSkeleton from '@/components/common/Skeleton/ProfileSkeleton';
 import { PATH } from '@/constants/path';
 import Layout from '@/pages/Layout/Layout';
 import LoginPage from '@/pages/LoginPage/LoginPage';
 import MainPage from '@/pages/MainPage/MainPage';
 import NotFoundPage from '@/pages/NotFoundPage/NotFoundPage';
 import OauthRedirectPage from '@/pages/OauthRedirectPage';
-import ProfilePage from '@/pages/ProfilePage/ProfilePage';
 import RegisterPage from '@/pages/RegisterPage/RegisterPage';
 import SearchResultPage from '@/pages/SearchResultPage/SearchResultPage';
 import ClubEventPage from '@/pages/club/ClubEventPage/ClubEventPage';
@@ -20,11 +20,14 @@ import SubmittedFormsPage from '@/pages/event/SubmittedFormsPage/SubmittedFormsP
 import WriteEventFormPage from '@/pages/event/WriteEventFormPage/WriteEventFormPage';
 import WriteEventInfoPage from '@/pages/event/WriteEventInfoPage/WriteEventInfoPage';
 
+import { Suspense, lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
 import PrivateLogin from './PrivateLogin';
 import PrivateManager from './PrivateManager';
 import PrivateMember from './PrivateMember';
+
+const ProfilePageLazy = lazy(() => import('@/pages/ProfilePage/ProfilePage')); // eslint-disable-line
 
 const router = createBrowserRouter([
   {
@@ -48,7 +51,14 @@ const router = createBrowserRouter([
           {
             element: <PrivateLogin />,
             children: [
-              { path: PATH.PROFILE(':category'), element: <ProfilePage /> },
+              {
+                path: PATH.PROFILE(':category'),
+                element: (
+                  <Suspense fallback={<ProfileSkeleton />}>
+                    <ProfilePageLazy />
+                  </Suspense>
+                ),
+              },
               { path: PATH.CREATE, element: <CreateClubPage /> },
               { path: PATH.EVENT.SUBMIT_FORM(':eventId'), element: <SubmitFormPage /> },
               {


### PR DESCRIPTION
## 📝요구사항과 구현내용
### 이미지 lazyLoad를 위한 훅 두 개 추가했습니다
useIsIntersection.ts : intersectionApi를 사용해서 타겟이 뷰포트 내에 진입했는지 판단을 도와줍니다.
useLazyImage.ts : useIsIntersection을 사용해서 이미지가 뷰포트 내에 진입했을 때 실제 이미지 src를 반환합니다. 진입 전에는 대체 이미지 src를 반환합니다.

### 프로필 페이지 코드 청크를 분할하여 지연 로딩했습니다
코드 스플리팅이라는 기법인데 왜 이따구로 어려운 단어를 쓰는지 모르겠습니다?
그냥 번들링 과정에서 코드를 하나의 청크로 안 묶고 여러개로 나눠 필요할 때마다 코드 청크를 가져오는 방식입니다.
최초 페이지 로딩 시간을 줄여줍니다.
https://ko.legacy.reactjs.org/docs/code-splitting.html < 참고하면 좋은 자료

### 프로필 페이지 스켈레톤 UI 추가
별거는 아니고 Spinner위에 헤더 컴포넌트를 추가했습니다.

<hr/>

일단 프로필 페이지에만 적용했습니다.
활용법이 쉬우니 순차적으로 적용하면 좋을 것 같습니다.

이미지 지연 로딩은 Poster 컴포넌트 옵션에 isLazy 하나만 추가하면 됩니다.

스플리팅도 한 줄만 추가하면 됩니다.
다만 스플리팅 할 떄 lazy컴포넌트는 suspense 컴포넌트 하위에서 렌더링되어야 합니다.
그 이유는 React.lazy는 Promise객체를 반환하는 비동기 함수입니다. ( 정확히는 export 모듈을 resolve하는 Promise입니다 )
페이지에 진입하고 필요한 js파일을 가져오는 동안 해당 Promise는 pending상태 입니다.
이 pending상태 동안 페이지를 대체할 fallback이 있어야 하기 때문에 suspense하위에 lazy컴포넌트가 존재해야 합니다.

## 구현 스크린샷
![image](https://github.com/Space-Club/Frontend/assets/42764685/c05127b4-2645-4be3-9085-cb53daec917a)

## ✨pr포인트 & 궁금한 점 
질문은 DM 부탁드립니다🙏 

페이지 로드 대략 0.7초 감소

성능 15% 향상

지금 성능이 낮게 나오는 이유는 이미지 원본을 그대로 주고 받기 때문으로 보입니다.