### PR TITLE
refactor : 메인페이지 포스터 이미지 지연 로딩

### DIFF
--- a/src/components/MainEvents.tsx
+++ b/src/components/MainEvents.tsx
@@ -50,6 +50,7 @@ const MainEvents = ({ pathname }: MainEventsProps) => {
               isEnded={eventInfo.isEnded}
               clubName={clubInfo.name}
               clubLogoImageUrl={clubInfo.logoImageUrl}
+              isLazy={true}
             />
           );
         })}

--- a/src/components/common/EventCard/EventCard.tsx
+++ b/src/components/common/EventCard/EventCard.tsx
@@ -24,6 +24,7 @@ interface EventProps {
   startDate?: string;
   endDate?: string;
   clubLogoImageUrl?: string;
+  isLazy?: boolean;
   clubName: string;
   openStatus?: string;
   isEnded: boolean;
@@ -40,12 +41,13 @@ const EventCard = ({
   clubName,
   openStatus,
   isEnded,
+  isLazy,
 }: EventProps) => {
   const navigate = useNavigate();
 
   return (
     <ContainerStyled onClick={() => navigate(PATH.EVENT.DETAIL(eventId))}>
-      <Poster posterSrc={posterSrc} width={9.5} isEnded={isEnded}>
+      <Poster isLazy={isLazy} posterSrc={posterSrc} width={9.5} isEnded={isEnded}>
         {openStatus && (
           <EventStatusTag
             eventTag={APPLIED_EVENTS_TAGS[openStatus === 'ALL' ? 'publicEvent' : 'clubOnlyEvent']}


### PR DESCRIPTION
## 📝요구사항과 구현내용
- https://github.com/Space-Club/Frontend/pull/247
- 메인 페이지에 포스터가 많아짐에 따라 부하가 많이 걸리던 현상을 해소하기 위해 이전 PR에서 프로필 페이지에 적용했던 이미지 지연 로딩을 메인페이지에 적용했습니다.
![image](https://github.com/Space-Club/Frontend/assets/42764685/6d19cb3d-73fd-417f-93e9-0c3ee6d43152)
- FCP성능이 획기적으로 좋아졌습니다!
- 이번 PR에 변경사항은 isLazy속성 추가 밖에 없습니다. 이전 PR을 참고하시면 내부 구현은 링크한 이전 PR을 참고하시면 좋을 것 같아요!




